### PR TITLE
Add settings page and import controls

### DIFF
--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -15,5 +15,8 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB) {
 		api.DELETE("/images/:id/tags", removeTags(db))
 		api.DELETE("/images/:id", deleteImage(db))
 		api.POST("/scan", scanFolder(db))
+		api.GET("/settings/libraryFolder", getLibraryFolder(db))
+		api.PUT("/settings/libraryFolder", setLibraryFolder(db))
+		api.POST("/settings/import", importLibrary(db))
 	}
 }

--- a/backend/api/settings.go
+++ b/backend/api/settings.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"gen-library/backend/db"
+	"gen-library/backend/scan"
+)
+
+func getLibraryFolder(gdb *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var s db.Setting
+		if err := gdb.First(&s, "key = ?", "libraryFolder").Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusOK, gin.H{"path": ""})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"path": s.Value})
+	}
+}
+
+func setLibraryFolder(gdb *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var body struct {
+			Path string `json:"path"`
+		}
+		if err := c.BindJSON(&body); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		if err := gdb.Save(&db.Setting{Key: "libraryFolder", Value: body.Path}).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	}
+}
+
+func importLibrary(gdb *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var s db.Setting
+		if err := gdb.First(&s, "key = ?", "libraryFolder").Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusOK, gin.H{"added": 0, "updated": 0})
+				return
+			}
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		added, updated, err := scan.ScanFolder(gdb, s.Value)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"added": added, "updated": updated})
+	}
+}

--- a/backend/db/migrations.go
+++ b/backend/db/migrations.go
@@ -49,13 +49,17 @@ func ApplyMigrations(gdb *gorm.DB) error {
 			FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
 		);`,
 		`CREATE TABLE IF NOT EXISTS user_metadata (
-			id INTEGER PRIMARY KEY,
-			image_id INTEGER NOT NULL,
-			key TEXT NOT NULL,
-			value TEXT NOT NULL,
-			UNIQUE(image_id, key),
-			FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
-		);`,
+                        id INTEGER PRIMARY KEY,
+                        image_id INTEGER NOT NULL,
+                        key TEXT NOT NULL,
+                        value TEXT NOT NULL,
+                        UNIQUE(image_id, key),
+                        FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+                );`,
+		`CREATE TABLE IF NOT EXISTS settings (
+                        key TEXT PRIMARY KEY,
+                        value TEXT NOT NULL
+                );`,
 		// Indexes
 		`CREATE INDEX IF NOT EXISTS images_nsfw_idx ON images(nsfw);`,
 		`CREATE INDEX IF NOT EXISTS images_model_idx ON images(model_name);`,

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -55,3 +55,8 @@ type UserMetadata struct {
 	Key     string `gorm:"not null"`
 	Value   string `gorm:"not null"`
 }
+
+type Setting struct {
+	Key   string `gorm:"primaryKey"`
+	Value string `gorm:"not null"`
+}

--- a/backend/scan/scanner.go
+++ b/backend/scan/scanner.go
@@ -3,12 +3,24 @@ package scan
 import (
 	"io/fs"
 	"log"
+	"os"
 	"path/filepath"
 
 	"gorm.io/gorm"
 )
 
-func ScanFolder(gdb *gorm.DB, root string) error {
+func ScanFolder(gdb *gorm.DB, root string) (int, int, error) {
+	if root == "" {
+		return 0, 0, nil
+	}
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			log.Printf("ScanFolder: folder %s does not exist", root)
+			return 0, 0, nil
+		}
+		return 0, 0, err
+	}
 	log.Printf("scan stub: would scan %s for images (*.png,*.jpg,*.jpeg,*.webp)", root)
-	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error { return nil })
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error { return nil })
+	return 0, 0, err
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "axios": "^1.11.0",
         "bootstrap": "^5.3.7",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -926,6 +927,12 @@
         "he": "^1.2.0"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/language-core": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.5.tgz",
@@ -1707,6 +1714,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vue-tsc": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "axios": "^1.11.0",
     "bootstrap": "^5.3.7",
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,19 @@
 <template>
-  <div class="container py-3">
-    <h1 class="h3 mb-3">AI Image Library</h1>
-    <LibraryView />
+  <div>
+    <nav class="navbar navbar-expand navbar-light bg-light mb-3">
+      <div class="container">
+        <a class="navbar-brand" href="#">AI Image Library</a>
+        <div class="navbar-nav">
+          <RouterLink to="/" class="nav-link">Library</RouterLink>
+          <RouterLink to="/settings" class="nav-link">Settings</RouterLink>
+        </div>
+      </div>
+    </nav>
+    <div class="container py-3">
+      <RouterView />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import LibraryView from './views/LibraryView.vue'
 </script>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -29,3 +29,18 @@ export async function getImage(id: number) {
   const { data } = await api.get(`/api/images/${id}`)
   return data
 }
+
+export async function getLibraryFolder() {
+  const { data } = await api.get('/api/settings/libraryFolder')
+  return data
+}
+
+export async function setLibraryFolder(path: string) {
+  const { data } = await api.put('/api/settings/libraryFolder', { path })
+  return data
+}
+
+export async function importLibrary() {
+  const { data } = await api.post('/api/settings/import')
+  return data
+}

--- a/frontend/src/components/ImageCard.vue
+++ b/frontend/src/components/ImageCard.vue
@@ -12,5 +12,5 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{ image: any }>()
+defineProps<{ image: any }>()
 </script>

--- a/frontend/src/components/ImageGrid.vue
+++ b/frontend/src/components/ImageGrid.vue
@@ -9,7 +9,7 @@
 <script setup lang="ts">
 import ImageCard from './ImageCard.vue'
 
-const props = defineProps<{ images: any[] }>()
+defineProps<{ images: any[] }>()
 
 const columnCount = Math.max(1, Math.min(5, Math.floor(window.innerWidth / 320)))
 </script>

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import router from './router'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -1,0 +1,13 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import LibraryView from './views/LibraryView.vue'
+import SettingsView from './views/SettingsView.vue'
+
+const routes = [
+  { path: '/', component: LibraryView },
+  { path: '/settings', component: SettingsView },
+]
+
+export default createRouter({
+  history: createWebHistory(),
+  routes,
+})

--- a/frontend/src/views/LibraryView.vue
+++ b/frontend/src/views/LibraryView.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
+import { ref, watchEffect, onMounted, onUnmounted } from 'vue'
 import { listImages } from '../api'
 import SidebarFilters from '../components/SidebarFilters.vue'
 import ImageGrid from '../components/ImageGrid.vue'
@@ -35,15 +35,7 @@ const order = ref<'asc'|'desc'>('desc')
 const items = ref<any[]>([])
 const total = ref(0)
 
-function reload() {
-  page.value = 1
-}
-
-function onPage(newPage: number) {
-  page.value = newPage
-}
-
-watchEffect(async () => {
+async function load() {
   const data = await listImages({
     page: page.value,
     pageSize: pageSize.value,
@@ -55,5 +47,19 @@ watchEffect(async () => {
   })
   items.value = data.items
   total.value = data.total
-})
+}
+
+function reload() {
+  page.value = 1
+  load()
+}
+
+function onPage(newPage: number) {
+  page.value = newPage
+}
+
+watchEffect(load)
+
+onMounted(() => window.addEventListener('library-updated', reload))
+onUnmounted(() => window.removeEventListener('library-updated', reload))
 </script>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="col-md-6">
+    <label class="form-label">Library Folder</label>
+    <input type="text" class="form-control mb-2" v-model="path" />
+    <button class="btn btn-primary me-2" @click="save">Save</button>
+    <button class="btn btn-secondary" @click="importNow">Import Now</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { getLibraryFolder, setLibraryFolder, importLibrary } from '../api'
+
+const path = ref('')
+
+async function load() {
+  const data = await getLibraryFolder()
+  path.value = data.path || ''
+}
+
+async function save() {
+  await setLibraryFolder(path.value)
+  alert('Saved')
+}
+
+async function importNow() {
+  const res = await importLibrary()
+  alert(`Added ${res.added}, Updated ${res.updated}`)
+  window.dispatchEvent(new Event('library-updated'))
+}
+
+onMounted(load)
+</script>


### PR DESCRIPTION
## Summary
- add settings table and API endpoints for library folder and manual import
- add Vue settings page with library path input and import trigger
- integrate vue-router and navigation links

## Testing
- `go test ./...`
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898effdd9d4833297a93ea42e0865cc