### PR TITLE
Add settings page with library import support

### DIFF
--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -6,14 +6,17 @@ import (
 )
 
 func RegisterRoutes(r *gin.Engine, db *gorm.DB) {
-	api := r.Group("/api")
-	{
-		api.GET("/images", listImages(db))
-		api.GET("/images/:id", getImage(db))
-		api.PUT("/images/:id/metadata", updateMetadata(db))
-		api.POST("/images/:id/tags", addTags(db))
-		api.DELETE("/images/:id/tags", removeTags(db))
-		api.DELETE("/images/:id", deleteImage(db))
-		api.POST("/scan", scanFolder(db))
-	}
+        api := r.Group("/api")
+        {
+                api.GET("/images", listImages(db))
+                api.GET("/images/:id", getImage(db))
+                api.PUT("/images/:id/metadata", updateMetadata(db))
+                api.POST("/images/:id/tags", addTags(db))
+                api.DELETE("/images/:id/tags", removeTags(db))
+                api.DELETE("/images/:id", deleteImage(db))
+                api.POST("/scan", scanFolder(db))
+               api.GET("/settings/libraryFolder", getLibraryFolder(db))
+               api.PUT("/settings/libraryFolder", setLibraryFolder(db))
+               api.POST("/settings/import", importLibrary(db))
+        }
 }

--- a/backend/api/settings.go
+++ b/backend/api/settings.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+    "net/http"
+
+    "github.com/gin-gonic/gin"
+    "gorm.io/gorm"
+
+    "gen-library/backend/scan"
+)
+
+func getLibraryFolder(db *gorm.DB) gin.HandlerFunc {
+    return func(c *gin.Context) {
+        var path string
+        db.Raw("SELECT value FROM settings WHERE key = ?", "libraryFolder").Scan(&path)
+        c.JSON(http.StatusOK, gin.H{"path": path})
+    }
+}
+
+func setLibraryFolder(db *gorm.DB) gin.HandlerFunc {
+    return func(c *gin.Context) {
+        var body struct{ Path string `json:"path"` }
+        if err := c.BindJSON(&body); err != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+            return
+        }
+        if err := db.Exec("INSERT INTO settings(key,value) VALUES(?,?) ON CONFLICT(key) DO UPDATE SET value=excluded.value", "libraryFolder", body.Path).Error; err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+            return
+        }
+        c.JSON(http.StatusOK, gin.H{"path": body.Path})
+    }
+}
+
+func importLibrary(db *gorm.DB) gin.HandlerFunc {
+    return func(c *gin.Context) {
+        var path string
+        db.Raw("SELECT value FROM settings WHERE key = ?", "libraryFolder").Scan(&path)
+        added, updated, err := scan.ScanFolder(db, path)
+        if err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+            return
+        }
+        c.JSON(http.StatusOK, gin.H{"added": added, "updated": updated})
+    }
+}
+

--- a/backend/db/migrations.go
+++ b/backend/db/migrations.go
@@ -48,15 +48,19 @@ func ApplyMigrations(gdb *gorm.DB) error {
 			FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
 			FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
 		);`,
-		`CREATE TABLE IF NOT EXISTS user_metadata (
-			id INTEGER PRIMARY KEY,
-			image_id INTEGER NOT NULL,
-			key TEXT NOT NULL,
-			value TEXT NOT NULL,
-			UNIQUE(image_id, key),
-			FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
-		);`,
-		// Indexes
+                `CREATE TABLE IF NOT EXISTS user_metadata (
+                        id INTEGER PRIMARY KEY,
+                        image_id INTEGER NOT NULL,
+                        key TEXT NOT NULL,
+                        value TEXT NOT NULL,
+                        UNIQUE(image_id, key),
+                        FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+                );`,
+               `CREATE TABLE IF NOT EXISTS settings (
+                       key TEXT PRIMARY KEY,
+                       value TEXT NOT NULL
+               );`,
+                // Indexes
 		`CREATE INDEX IF NOT EXISTS images_nsfw_idx ON images(nsfw);`,
 		`CREATE INDEX IF NOT EXISTS images_model_idx ON images(model_name);`,
 		`CREATE INDEX IF NOT EXISTS image_tags_image_idx ON image_tags(image_id);`,

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -50,8 +50,13 @@ type ImageTag struct {
 }
 
 type UserMetadata struct {
-	ID      uint   `gorm:"primaryKey"`
-	ImageID uint   `gorm:"index;not null"`
-	Key     string `gorm:"not null"`
-	Value   string `gorm:"not null"`
+        ID      uint   `gorm:"primaryKey"`
+        ImageID uint   `gorm:"index;not null"`
+        Key     string `gorm:"not null"`
+        Value   string `gorm:"not null"`
+}
+
+type Setting struct {
+       Key   string `gorm:"primaryKey"`
+       Value string `gorm:"not null"`
 }

--- a/backend/scan/scanner.go
+++ b/backend/scan/scanner.go
@@ -1,14 +1,32 @@
 package scan
 
 import (
-	"io/fs"
-	"log"
-	"path/filepath"
+        "io/fs"
+        "log"
+        "os"
+        "path/filepath"
 
-	"gorm.io/gorm"
+        "gorm.io/gorm"
 )
 
-func ScanFolder(gdb *gorm.DB, root string) error {
-	log.Printf("scan stub: would scan %s for images (*.png,*.jpg,*.jpeg,*.webp)", root)
-	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error { return nil })
+// ScanFolder walks the given root folder and imports images.
+// Returns counts of added and updated images.
+func ScanFolder(gdb *gorm.DB, root string) (int, int, error) {
+        if root == "" {
+                log.Printf("scan skipped: no folder configured")
+                return 0, 0, nil
+        }
+        if info, err := os.Stat(root); err != nil || !info.IsDir() {
+                if err != nil {
+                        log.Printf("scan skipped: %v", err)
+                } else {
+                        log.Printf("scan skipped: %s is not a directory", root)
+                }
+                return 0, 0, nil
+        }
+        log.Printf("scan stub: would scan %s for images (*.png,*.jpg,*.jpeg,*.webp)", root)
+        if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error { return nil }); err != nil {
+                return 0, 0, err
+        }
+        return 0, 0, nil
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "axios": "^1.11.0",
         "bootstrap": "^5.3.7",
-        "vue": "^3.5.18"
+        "vue": "^3.5.18",
+        "vue-router": "^4.4.5"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^6.0.1",
@@ -926,6 +927,12 @@
         "he": "^1.2.0"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/language-core": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.0.5.tgz",
@@ -1707,6 +1714,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vue-tsc": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "axios": "^1.11.0",
     "bootstrap": "^5.3.7",
-    "vue": "^3.5.18"
+    "vue": "^3.5.18",
+    "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.1",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,19 @@
 <template>
   <div class="container py-3">
     <h1 class="h3 mb-3">AI Image Library</h1>
-    <LibraryView />
+    <nav class="mb-3">
+      <ul class="nav nav-pills">
+        <li class="nav-item">
+          <router-link to="/" class="nav-link" active-class="active" exact-active-class="active">Library</router-link>
+        </li>
+        <li class="nav-item">
+          <router-link to="/settings" class="nav-link" active-class="active">Settings</router-link>
+        </li>
+      </ul>
+    </nav>
+    <router-view />
   </div>
 </template>
 
 <script setup lang="ts">
-import LibraryView from './views/LibraryView.vue'
 </script>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -33,3 +33,18 @@ export async function getImage(id: number) {
   const { data } = await api.get(`/api/images/${id}`)
   return data
 }
+
+export async function getLibraryFolder() {
+  const { data } = await api.get('/api/settings/libraryFolder')
+  return data
+}
+
+export async function setLibraryFolder(path: string) {
+  const { data } = await api.put('/api/settings/libraryFolder', { path })
+  return data
+}
+
+export async function importLibrary() {
+  const { data } = await api.post('/api/settings/import')
+  return data
+}

--- a/frontend/src/components/ImageCard.vue
+++ b/frontend/src/components/ImageCard.vue
@@ -12,5 +12,5 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{ image: any }>()
+defineProps<{ image: any }>()
 </script>

--- a/frontend/src/components/ImageGrid.vue
+++ b/frontend/src/components/ImageGrid.vue
@@ -9,7 +9,7 @@
 <script setup lang="ts">
 import ImageCard from './ImageCard.vue'
 
-const props = defineProps<{ images: any[] }>()
+defineProps<{ images: any[] }>()
 
 const columnCount = Math.max(1, Math.min(5, Math.floor(window.innerWidth / 320)))
 </script>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 import 'bootstrap/dist/css/bootstrap.min.css'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -1,0 +1,15 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import LibraryView from './views/LibraryView.vue'
+import SettingsView from './views/SettingsView.vue'
+
+const routes = [
+  { path: '/', component: LibraryView },
+  { path: '/settings', component: SettingsView }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+export default router

--- a/frontend/src/views/LibraryView.vue
+++ b/frontend/src/views/LibraryView.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
+import { ref, watchEffect, onMounted, onUnmounted } from 'vue'
 import { listImages } from '../api'
 import SidebarFilters from '../components/SidebarFilters.vue'
 import ImageGrid from '../components/ImageGrid.vue'
@@ -55,5 +55,13 @@ watchEffect(async () => {
   })
   items.value = data.items
   total.value = data.total
+})
+
+onMounted(() => {
+  window.addEventListener('library-updated', reload)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('library-updated', reload)
 })
 </script>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <div class="mb-3">
+      <label class="form-label">Library Folder</label>
+      <input v-model="path" type="text" class="form-control" />
+    </div>
+    <button class="btn btn-primary me-2" @click="save">Save</button>
+    <button class="btn btn-secondary" @click="importNow">Import Now</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { getLibraryFolder, setLibraryFolder, importLibrary } from '../api'
+
+const path = ref('')
+
+onMounted(async () => {
+  const data = await getLibraryFolder()
+  path.value = data.path || ''
+})
+
+async function save() {
+  await setLibraryFolder(path.value)
+  alert('Saved')
+}
+
+async function importNow() {
+  const res = await importLibrary()
+  alert(`Added ${res.added}, updated ${res.updated}`)
+  window.dispatchEvent(new Event('library-updated'))
+}
+</script>
+


### PR DESCRIPTION
## Summary
- add settings table and API for library folder and import trigger
- implement Settings view with save/import actions and router/nav updates
- ensure ScanFolder gracefully handles missing folders

## Testing
- `npm run build`
- `cd backend && go build ./... && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_6898fc8c26648332935e8293844293c7