### PR TITLE
Use saved library path for scanning

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -39,7 +39,7 @@ export async function setLibraryPath(path: string) {
   await api.put('/api/settings/library_path', { value: path })
 }
 
-export async function scanLibrary() {
-  const { data } = await api.post('/api/scan')
+export async function scanLibrary(root?: string) {
+  const { data } = await api.post('/api/scan', root ? { root } : undefined)
   return data
 }

--- a/frontend/src/views/LibraryView.vue
+++ b/frontend/src/views/LibraryView.vue
@@ -22,7 +22,7 @@
 
 <script setup lang="ts">
 import { ref, watchEffect } from 'vue'
-import { listImages, scanLibrary } from '../api'
+import { listImages, scanLibrary, getLibraryPath } from '../api'
 import SidebarFilters from '../components/SidebarFilters.vue'
 import ImageGrid from '../components/ImageGrid.vue'
 import Pager from '../components/Pager.vue'
@@ -47,7 +47,12 @@ function onPage(newPage: number) {
 }
 
 async function onScan() {
-  await scanLibrary()
+  const root = await getLibraryPath()
+  if (!root) {
+    alert('Please set a library path in Settings first')
+    return
+  }
+  await scanLibrary(root)
   reload()
 }
 

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -22,7 +22,11 @@ onMounted(async () => {
 })
 
 async function save() {
-  await setLibraryPath(path.value)
+  if (!path.value.trim()) {
+    alert('Please enter a folder path')
+    return
+  }
+  await setLibraryPath(path.value.trim())
   alert('Saved')
 }
 </script>


### PR DESCRIPTION
## Summary
- ensure settings page validates and saves library folder path
- use saved library path when triggering library scan
- allow optional scan root parameter in API helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `go test ./...` *(no output, command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68993e4b7f548332a107530a40894ed6