### PR TITLE
feat: enable dark theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AI Image Library</title>
   </head>
-  <body>
+  <body class="bg-dark text-light">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/frontend/src/components/ImageCard.vue
+++ b/frontend/src/components/ImageCard.vue
@@ -12,5 +12,5 @@
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{ image: any }>()
+defineProps<{ image: any }>()
 </script>

--- a/frontend/src/components/ImageGrid.vue
+++ b/frontend/src/components/ImageGrid.vue
@@ -9,7 +9,7 @@
 <script setup lang="ts">
 import ImageCard from './ImageCard.vue'
 
-const props = defineProps<{ images: any[] }>()
+defineProps<{ images: any[] }>()
 
 const columnCount = Math.max(1, Math.min(5, Math.floor(window.innerWidth / 320)))
 </script>

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+// Allow importing of CSS files in TypeScript modules
+declare module '*.css';
+


### PR DESCRIPTION
## Summary
- switch UI to Bootstrap's dark theme
- tidy Vue components and add CSS module typings

## Testing
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_68a15a8ed74c83328ceee77b33e10e1f