### PR TITLE
Use configurable backend port

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,8 @@
 import axios from 'axios'
 
-const api = axios.create({ baseURL: 'http://localhost:8080' })
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
+})
 
 export interface ListParams {
   page?: number

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -3,3 +3,11 @@
 // Allow importing of CSS files in TypeScript modules
 declare module '*.css';
 
+interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+


### PR DESCRIPTION
## Summary
- point frontend API requests at the backend's default port 8081
- allow the backend URL to be overridden via `VITE_API_BASE_URL`

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a21fba2ab08332b157b669d4b4b38b