### PR TITLE
feat: add metadata panel with tag editor

### DIFF
--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -7,56 +7,56 @@ import (
 )
 
 type Image struct {
-	ID          uint   `gorm:"primaryKey"`
-	Path        string `gorm:"uniqueIndex;not null"`
-	FileName    string `gorm:"not null"`
-	Ext         string `gorm:"not null"`
-	SizeBytes   int64  `gorm:"not null"`
-	SHA256      string `gorm:"uniqueIndex;not null"`
-	Width       *int
-	Height      *int
-	CreatedTime *time.Time
-	ImportedAt  time.Time `gorm:"autoCreateTime"`
+	ID          uint       `gorm:"primaryKey" json:"id"`
+	Path        string     `gorm:"uniqueIndex;not null" json:"path"`
+	FileName    string     `gorm:"not null" json:"fileName"`
+	Ext         string     `gorm:"not null" json:"ext"`
+	SizeBytes   int64      `gorm:"not null" json:"sizeBytes"`
+	SHA256      string     `gorm:"uniqueIndex;not null" json:"sha256"`
+	Width       *int       `json:"width"`
+	Height      *int       `json:"height"`
+	CreatedTime *time.Time `json:"createdTime"`
+	ImportedAt  time.Time  `gorm:"autoCreateTime" json:"importedAt"`
 
-	SourceApp      *string
-	ModelName      *string
-	ModelHash      *string
-	Prompt         *string
-	NegativePrompt *string
-	Sampler        *string
-	Steps          *int
-	CFGScale       *float64
-	Seed           *string
-	Scheduler      *string
-	ClipSkip       *int
+	SourceApp      *string  `json:"sourceApp"`
+	ModelName      *string  `json:"modelName"`
+	ModelHash      *string  `json:"modelHash"`
+	Prompt         *string  `json:"prompt"`
+	NegativePrompt *string  `json:"negativePrompt"`
+	Sampler        *string  `json:"sampler"`
+	Steps          *int     `json:"steps"`
+	CFGScale       *float64 `json:"cfgScale"`
+	Seed           *string  `json:"seed"`
+	Scheduler      *string  `json:"scheduler"`
+	ClipSkip       *int     `json:"clipSkip"`
 
-	NSFW   bool `gorm:"default:false"`
-	Hidden bool `gorm:"default:false"`
+	NSFW   bool `gorm:"default:false" json:"nsfw"`
+	Hidden bool `gorm:"default:false" json:"hidden"`
 
-	RawMetadata datatypes.JSON
+	RawMetadata datatypes.JSON `json:"rawMetadata"`
 
-	Tags     []*Tag         `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE"`
-	UserMeta []UserMetadata `gorm:"constraint:OnDelete:CASCADE"`
+	Tags     []*Tag         `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
+	UserMeta []UserMetadata `gorm:"constraint:OnDelete:CASCADE" json:"userMeta"`
 }
 
 type Tag struct {
-	ID   uint   `gorm:"primaryKey"`
-	Name string `gorm:"uniqueIndex;not null"`
+	ID   uint   `gorm:"primaryKey" json:"id"`
+	Name string `gorm:"uniqueIndex;not null" json:"name"`
 }
 
 type ImageTag struct {
-	ImageID uint `gorm:"primaryKey"`
-	TagID   uint `gorm:"primaryKey"`
+	ImageID uint `gorm:"primaryKey" json:"imageId"`
+	TagID   uint `gorm:"primaryKey" json:"tagId"`
 }
 
 type UserMetadata struct {
-	ID      uint   `gorm:"primaryKey"`
-	ImageID uint   `gorm:"index;not null"`
-	Key     string `gorm:"not null"`
-	Value   string `gorm:"not null"`
+	ID      uint   `gorm:"primaryKey" json:"id"`
+	ImageID uint   `gorm:"index;not null" json:"imageId"`
+	Key     string `gorm:"not null" json:"key"`
+	Value   string `gorm:"not null" json:"value"`
 }
 
 type Setting struct {
-	Key   string `gorm:"primaryKey"`
-	Value string `gorm:"not null"`
+	Key   string `gorm:"primaryKey" json:"key"`
+	Value string `gorm:"not null" json:"value"`
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -49,3 +49,18 @@ export async function scanLibrary(root?: string) {
 export async function deleteImage(id: number, mode: 'trash' | 'hard' = 'trash') {
   await api.delete(`/api/images/${id}`, { params: { mode } })
 }
+
+export async function updateImageMetadata(id: number, metadata: any) {
+  const { data } = await api.put(`/api/images/${id}/metadata`, metadata)
+  return data
+}
+
+export async function addTags(id: number, tags: string[]) {
+  const { data } = await api.post(`/api/images/${id}/tags`, { tags })
+  return data
+}
+
+export async function removeTags(id: number, tags: string[]) {
+  const { data } = await api.delete(`/api/images/${id}/tags`, { data: { tags } })
+  return data
+}

--- a/frontend/src/components/ImageCard.vue
+++ b/frontend/src/components/ImageCard.vue
@@ -12,6 +12,7 @@
         <small class="text-truncate" style="max-width: 80%">{{ image.fileName }}</small>
         <div class="d-flex align-items-center gap-1">
           <span v-if="image.nsfw" class="badge text-bg-danger">NSFW</span>
+          <button class="btn btn-sm btn-outline-primary" @click="onMetadata">Metadata</button>
           <button class="btn btn-sm btn-outline-danger" @click="onDelete">Delete</button>
         </div>
       </div>
@@ -25,11 +26,15 @@ import { deleteImage } from '../api'
 
 const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
 const props = defineProps<{ image: any }>()
-const emit = defineEmits(['deleted'])
+const emit = defineEmits(['deleted', 'metadata'])
 
 async function onDelete() {
   if (!confirm('Delete this image?')) return
   await deleteImage(props.image.id)
   emit('deleted', props.image.id)
+}
+
+function onMetadata() {
+  emit('metadata', props.image)
 }
 </script>

--- a/frontend/src/components/ImageGrid.vue
+++ b/frontend/src/components/ImageGrid.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="masonry" :style="{ columnCount }">
     <div v-for="img in images" :key="img.id" class="mb-3 break-inside-avoid">
-      <ImageCard :image="img" @deleted="emit('deleted', $event)" />
+      <ImageCard
+        :image="img"
+        @deleted="emit('deleted', $event)"
+        @metadata="emit('metadata', $event)"
+      />
     </div>
   </div>
 </template>
@@ -10,7 +14,7 @@
 import ImageCard from './ImageCard.vue'
 
 defineProps<{ images: any[] }>()
-const emit = defineEmits(['deleted'])
+const emit = defineEmits(['deleted', 'metadata'])
 
 const columnCount = Math.max(1, Math.min(5, Math.floor(window.innerWidth / 320)))
 </script>

--- a/frontend/src/components/MetadataPanel.vue
+++ b/frontend/src/components/MetadataPanel.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="card">
+    <div class="card-body">
+      <div class="mb-3">
+        <label class="form-label">Model</label>
+        <input class="form-control" v-model="form.modelName" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Model Hash</label>
+        <input class="form-control" v-model="form.modelHash" />
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Prompt</label>
+        <textarea class="form-control" rows="3" v-model="form.prompt"></textarea>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Negative Prompt</label>
+        <textarea class="form-control" rows="3" v-model="form.negativePrompt"></textarea>
+      </div>
+      <div class="row mb-3">
+        <div class="col">
+          <label class="form-label">Sampler</label>
+          <input class="form-control" v-model="form.sampler" />
+        </div>
+        <div class="col">
+          <label class="form-label">Steps</label>
+          <input class="form-control" type="number" v-model="form.steps" />
+        </div>
+        <div class="col">
+          <label class="form-label">CFG</label>
+          <input class="form-control" type="number" step="0.1" v-model="form.cfgScale" />
+        </div>
+        <div class="col">
+          <label class="form-label">Seed</label>
+          <input class="form-control" v-model="form.seed" />
+        </div>
+      </div>
+      <div class="row mb-3">
+        <div class="col">
+          <label class="form-label">Scheduler</label>
+          <input class="form-control" v-model="form.scheduler" />
+        </div>
+        <div class="col">
+          <label class="form-label">Clip Skip</label>
+          <input class="form-control" type="number" v-model="form.clipSkip" />
+        </div>
+        <div class="col">
+          <label class="form-label">Source App</label>
+          <input class="form-control" v-model="form.sourceApp" />
+        </div>
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">Tags</label>
+        <TagEditor :image-id="props.image.id" v-model:tags="tags" />
+      </div>
+
+      <div class="mb-3">
+        <button class="btn btn-link p-0" type="button" @click="rawOpen = !rawOpen">
+          {{ rawOpen ? 'Hide Raw JSON' : 'Show Raw JSON' }}
+        </button>
+        <pre v-if="rawOpen" class="mt-2"><code>{{ rawJson }}</code></pre>
+      </div>
+
+      <div class="d-grid">
+        <button class="btn btn-primary" @click="onSave">Save</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, watch, computed } from 'vue'
+import TagEditor from './TagEditor.vue'
+import { updateImageMetadata } from '../api'
+
+const props = defineProps<{ image: any }>()
+const emit = defineEmits(['saved'])
+
+const form = reactive({
+  modelName: '',
+  modelHash: '',
+  prompt: '',
+  negativePrompt: '',
+  sampler: '',
+  steps: '' as any,
+  cfgScale: '' as any,
+  seed: '',
+  scheduler: '',
+  clipSkip: '' as any,
+  sourceApp: ''
+})
+
+const tags = ref<string[]>([])
+const rawOpen = ref(false)
+
+watch(() => props.image, (img) => {
+  form.modelName = img?.modelName ?? ''
+  form.modelHash = img?.modelHash ?? ''
+  form.prompt = img?.prompt ?? ''
+  form.negativePrompt = img?.negativePrompt ?? ''
+  form.sampler = img?.sampler ?? ''
+  form.steps = img?.steps ?? ''
+  form.cfgScale = img?.cfgScale ?? ''
+  form.seed = img?.seed ?? ''
+  form.scheduler = img?.scheduler ?? ''
+  form.clipSkip = img?.clipSkip ?? ''
+  form.sourceApp = img?.sourceApp ?? ''
+  tags.value = img?.tags?.map((t: any) => t.name) ?? []
+  rawOpen.value = false
+}, { immediate: true })
+
+const rawJson = computed(() => {
+  try {
+    return JSON.stringify(props.image?.rawMetadata || {}, null, 2)
+  } catch {
+    return ''
+  }
+})
+
+async function onSave() {
+  const payload: any = {
+    modelName: form.modelName || null,
+    modelHash: form.modelHash || null,
+    prompt: form.prompt || null,
+    negativePrompt: form.negativePrompt || null,
+    sampler: form.sampler || null,
+    steps: form.steps !== '' ? Number(form.steps) : null,
+    cfgScale: form.cfgScale !== '' ? Number(form.cfgScale) : null,
+    seed: form.seed || null,
+    scheduler: form.scheduler || null,
+    clipSkip: form.clipSkip !== '' ? Number(form.clipSkip) : null,
+    sourceApp: form.sourceApp || null
+  }
+  await updateImageMetadata(props.image.id, payload)
+  emit('saved')
+}
+</script>
+

--- a/frontend/src/components/TagEditor.vue
+++ b/frontend/src/components/TagEditor.vue
@@ -1,0 +1,61 @@
+<template>
+  <div>
+    <div class="mb-2">
+      <span
+        v-for="tag in localTags"
+        :key="tag"
+        class="badge text-bg-secondary me-1 mb-1"
+      >
+        {{ tag }}
+        <button
+          type="button"
+          class="btn-close btn-close-white btn-sm ms-1"
+          aria-label="Remove"
+          @click="onRemove(tag)"
+        ></button>
+      </span>
+    </div>
+    <div class="input-group">
+      <input
+        class="form-control"
+        v-model="newTag"
+        @keyup.enter="onAdd"
+        placeholder="Add tag"
+      />
+      <button class="btn btn-outline-primary" @click="onAdd" :disabled="!newTag.trim()">Add</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { addTags, removeTags } from '../api'
+
+const props = defineProps<{ imageId: number, tags: string[] }>()
+const emit = defineEmits(['update:tags'])
+
+const localTags = ref<string[]>([])
+const newTag = ref('')
+
+watch(() => props.tags, (v) => {
+  localTags.value = [...v]
+}, { immediate: true })
+
+async function onAdd() {
+  const tag = newTag.value.trim()
+  if (!tag) return
+  await addTags(props.imageId, [tag])
+  const updated = [...localTags.value, tag]
+  localTags.value = updated
+  emit('update:tags', updated)
+  newTag.value = ''
+}
+
+async function onRemove(tag: string) {
+  await removeTags(props.imageId, [tag])
+  const updated = localTags.value.filter(t => t !== tag)
+  localTags.value = updated
+  emit('update:tags', updated)
+}
+</script>
+

--- a/frontend/src/views/LibraryView.vue
+++ b/frontend/src/views/LibraryView.vue
@@ -14,18 +14,36 @@
       <div class="d-flex justify-content-end mb-2">
         <button class="btn btn-sm btn-secondary" @click="onScan">Scan Library</button>
       </div>
-      <ImageGrid :images="items" @deleted="onDeleted" />
+      <ImageGrid :images="items" @deleted="onDeleted" @metadata="onMetadata" />
       <Pager :page="page" :page-size="pageSize" :total="total" @change="onPage" />
     </div>
+  </div>
+
+  <div v-if="metadataOpen">
+    <div class="modal fade show d-block" tabindex="-1">
+      <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content bg-dark text-light">
+          <div class="modal-header">
+            <h5 class="modal-title">Image Metadata</h5>
+            <button type="button" class="btn-close btn-close-white" @click="closeMetadata"></button>
+          </div>
+          <div class="modal-body">
+            <MetadataPanel v-if="selectedImage" :image="selectedImage" @saved="onMetadataSaved" />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="modal-backdrop fade show"></div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, watchEffect } from 'vue'
-import { listImages, scanLibrary, getLibraryPath } from '../api'
+import { listImages, scanLibrary, getLibraryPath, getImage } from '../api'
 import SidebarFilters from '../components/SidebarFilters.vue'
 import ImageGrid from '../components/ImageGrid.vue'
 import Pager from '../components/Pager.vue'
+import MetadataPanel from '../components/MetadataPanel.vue'
 
 const page = ref(1)
 const pageSize = ref(50)
@@ -37,6 +55,8 @@ const order = ref<'asc'|'desc'>('desc')
 
 const items = ref<any[]>([])
 const total = ref(0)
+const metadataOpen = ref(false)
+const selectedImage = ref<any|null>(null)
 
 function reload() {
   page.value = 1
@@ -58,6 +78,25 @@ async function onScan() {
 
 function onDeleted(id: number) {
   items.value = items.value.filter(img => img.id !== id)
+}
+
+async function onMetadata(img: any) {
+  selectedImage.value = await getImage(img.id)
+  metadataOpen.value = true
+}
+
+function closeMetadata() {
+  metadataOpen.value = false
+  selectedImage.value = null
+}
+
+async function onMetadataSaved() {
+  if (selectedImage.value) {
+    const updated = await getImage(selectedImage.value.id)
+    const idx = items.value.findIndex(i => i.id === updated.id)
+    if (idx !== -1) items.value[idx] = updated
+  }
+  closeMetadata()
 }
 
 watchEffect(async () => {


### PR DESCRIPTION
## Summary
- add MetadataPanel.vue to edit image metadata, toggle raw JSON, and save changes
- create TagEditor.vue for adding and removing tags
- extend api.ts with metadata and tag update helpers
- allow opening the metadata panel directly from each gallery image
- expose image rawMetadata and other fields via JSON tags so frontend can display raw JSON

## Testing
- `go build ./...`
- `cd frontend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a276724188833295b8755562f14191