### PR TITLE
feat: add fullscreen image viewer

### DIFF
--- a/backend/api/images.go
+++ b/backend/api/images.go
@@ -130,14 +130,31 @@ func listImages(gdb *gorm.DB) gin.HandlerFunc {
 }
 
 func getImage(gdb *gorm.DB) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		var m db.Image
-		if err := gdb.Preload("Tags").Preload("UserMeta").Preload("Loras").First(&m, c.Param("id")).Error; err != nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-			return
-		}
-		c.JSON(http.StatusOK, m)
-	}
+        return func(c *gin.Context) {
+                var m db.Image
+                if err := gdb.Preload("Tags").Preload("UserMeta").Preload("Loras").First(&m, c.Param("id")).Error; err != nil {
+                        c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+                        return
+                }
+                c.JSON(http.StatusOK, m)
+        }
+}
+
+func serveImage(gdb *gorm.DB) gin.HandlerFunc {
+        return func(c *gin.Context) {
+                var img db.Image
+                if err := gdb.First(&img, c.Param("id")).Error; err != nil {
+                        c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+                        return
+                }
+                var root string
+                gdb.Table("settings").Select("value").Where("key=?", "library_path").Scan(&root)
+                path := img.Path
+                if root != "" && !filepath.IsAbs(path) {
+                        path = filepath.Join(root, path)
+                }
+                c.File(path)
+        }
 }
 
 func updateMetadata(gdb *gorm.DB) gin.HandlerFunc {

--- a/backend/api/router.go
+++ b/backend/api/router.go
@@ -6,15 +6,16 @@ import (
 )
 
 func RegisterRoutes(r *gin.Engine, db *gorm.DB) {
-	api := r.Group("/api")
-	{
-		api.GET("/images", listImages(db))
-		api.GET("/images/:id", getImage(db))
-		api.PUT("/images/:id/metadata", updateMetadata(db))
-		api.POST("/images/:id/tags", addTags(db))
-		api.DELETE("/images/:id/tags", removeTags(db))
-		api.DELETE("/images/:id", deleteImage(db))
-		api.POST("/scan", scanFolder(db))
+        api := r.Group("/api")
+        {
+                api.GET("/images", listImages(db))
+                api.GET("/images/:id", getImage(db))
+                api.GET("/images/:id/file", serveImage(db))
+                api.PUT("/images/:id/metadata", updateMetadata(db))
+                api.POST("/images/:id/tags", addTags(db))
+                api.DELETE("/images/:id/tags", removeTags(db))
+                api.DELETE("/images/:id", deleteImage(db))
+                api.POST("/scan", scanFolder(db))
 		api.GET("/settings/:key", getSetting(db))
 		api.PUT("/settings/:key", setSetting(db))
 	}

--- a/frontend/src/components/ImageCard.vue
+++ b/frontend/src/components/ImageCard.vue
@@ -6,6 +6,7 @@
       class="card-img-top"
       :alt="image.fileName"
       loading="lazy"
+      @click="onView"
     />
     <div class="card-body p-2">
       <div class="d-flex justify-content-between align-items-center">
@@ -35,6 +36,10 @@ async function onDelete() {
 }
 
 function onMetadata() {
+  emit('metadata', props.image)
+}
+
+function onView() {
   emit('metadata', props.image)
 }
 </script>

--- a/frontend/src/views/LibraryView.vue
+++ b/frontend/src/views/LibraryView.vue
@@ -21,14 +21,26 @@
 
   <div v-if="metadataOpen">
     <div class="modal fade show d-block" tabindex="-1">
-      <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-dialog modal-fullscreen">
         <div class="modal-content bg-dark text-light">
           <div class="modal-header">
-            <h5 class="modal-title">Image Metadata</h5>
+            <h5 class="modal-title">{{ selectedImage?.fileName }}</h5>
             <button type="button" class="btn-close btn-close-white" @click="closeMetadata"></button>
           </div>
-          <div class="modal-body">
-            <MetadataPanel v-if="selectedImage" :image="selectedImage" @saved="onMetadataSaved" />
+          <div class="modal-body p-0">
+            <div class="row g-0 h-100">
+              <div class="col-md-8 d-flex align-items-center justify-content-center bg-black">
+                <img
+                  v-if="selectedImage"
+                  :src="apiBase + '/api/images/' + selectedImage.id + '/file'"
+                  class="img-fluid"
+                  :alt="selectedImage.fileName"
+                />
+              </div>
+              <div class="col-md-4 overflow-auto p-3">
+                <MetadataPanel v-if="selectedImage" :image="selectedImage" @saved="onMetadataSaved" />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -44,6 +56,8 @@ import SidebarFilters from '../components/SidebarFilters.vue'
 import ImageGrid from '../components/ImageGrid.vue'
 import Pager from '../components/Pager.vue'
 import MetadataPanel from '../components/MetadataPanel.vue'
+
+const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
 
 const page = ref(1)
 const pageSize = ref(50)


### PR DESCRIPTION
## Summary
- add backend route to serve full-size image files
- show images in fullscreen modal with metadata panel
- allow clicking thumbnails to open viewer

## Testing
- `npm run build`
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a355a651b88332925e6a0fbb2e829b