### PR TITLE
fix: refresh library and resolve scanner issues

### DIFF
--- a/frontend/src/views/LibraryView.vue
+++ b/frontend/src/views/LibraryView.vue
@@ -31,7 +31,7 @@
               <div class="col-md-8 d-flex align-items-center justify-content-center bg-black">
                 <img
                   v-if="selectedImage"
-                  :src="apiBase + '/api/images/' + selectedImage.id + '/file'"
+                  :src="apiBase + '/api/images/' + selectedImage.id + '/file?sha=' + selectedImage.sha256"
                   class="img-fluid"
                   :alt="selectedImage.fileName"
                 />
@@ -83,9 +83,11 @@ const total = ref(0)
 const metadataOpen = ref(false)
 const selectedImage = ref<any|null>(null)
 const metadataEditing = ref(false)
+const reloadKey = ref(0)
 
 function reload() {
   page.value = 1
+  reloadKey.value++
 }
 
 function onPage(newPage: number) {
@@ -143,6 +145,7 @@ async function onDeleteSelected() {
 }
 
 watchEffect(async () => {
+  reloadKey.value
   const data = await listImages({
     page: page.value,
     pageSize: pageSize.value,


### PR DESCRIPTION
## Summary
- include image sha in modal URL to avoid mismatched full-size images
- refresh library listing after scanning for new files
- avoid noisy `record not found` messages during scanning

## Testing
- `npm --prefix frontend test` *(fails: Missing script: "test")*
- `npm --prefix frontend run build`
- `(cd backend && go test ./...)`


------
https://chatgpt.com/codex/tasks/task_e_68a3ea14bc688332bbbb89ff6d91c3cb