### PR TITLE
fix: allow dev proxy to backend

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,8 +3,10 @@ import axios from 'axios'
 // Use a relative base URL by default so that Vite's dev server proxy
 // can forward API requests to the backend. This avoids hard-coding
 // "localhost", which breaks when accessing the app from other devices.
+export const apiBase = import.meta.env.VITE_API_BASE_URL || ''
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL || ''
+  baseURL: apiBase
 })
 
 export interface ListParams {

--- a/frontend/src/components/ImageCard.vue
+++ b/frontend/src/components/ImageCard.vue
@@ -19,20 +19,18 @@
   </div>
 </template>
 
-<script setup lang="ts">
-import { deleteImage } from '../api'
+  <script setup lang="ts">
+  import { deleteImage, apiBase } from '../api'
+  const props = defineProps<{ image: any }>()
+  const emit = defineEmits(['deleted', 'metadata'])
 
-const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
-const props = defineProps<{ image: any }>()
-const emit = defineEmits(['deleted', 'metadata'])
+  async function onDelete() {
+    if (!confirm('Delete this image?')) return
+    await deleteImage(props.image.id)
+    emit('deleted', props.image.id)
+  }
 
-async function onDelete() {
-  if (!confirm('Delete this image?')) return
-  await deleteImage(props.image.id)
-  emit('deleted', props.image.id)
-}
-
-function onView() {
-  emit('metadata', props.image)
-}
+  function onView() {
+    emit('metadata', props.image)
+  }
 </script>

--- a/frontend/src/views/LibraryView.vue
+++ b/frontend/src/views/LibraryView.vue
@@ -61,15 +61,13 @@
 
 <script setup lang="ts">
 import { ref, watchEffect } from 'vue'
-import { listImages, scanLibrary, getLibraryPath, getImage, deleteImage } from '../api'
+import { listImages, scanLibrary, getLibraryPath, getImage, deleteImage, apiBase } from '../api'
 import SidebarFilters from '../components/SidebarFilters.vue'
 import ImageGrid from '../components/ImageGrid.vue'
 import Pager from '../components/Pager.vue'
 import MetadataPanel from '../components/MetadataPanel.vue'
 import MetadataDisplay from '../components/MetadataDisplay.vue'
 import { nsfw } from '../nsfw'
-
-const apiBase = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8081'
 
 const page = ref(1)
 const pageSize = ref(50)


### PR DESCRIPTION
## Summary
- use relative axios base URL so Vite's proxy forwards to backend

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3f3e5724c83328c9c0a94d97364ec