### PR TITLE
Add navigation and keyboard shortcuts to fullscreen viewer

### DIFF
--- a/frontend/src/components/MetadataPanel.vue
+++ b/frontend/src/components/MetadataPanel.vue
@@ -164,5 +164,7 @@ function addLora() {
 function removeLora(i: number) {
   loras.value.splice(i, 1)
 }
+
+defineExpose({ save: onSave })
 </script>
 

--- a/frontend/src/views/LibraryView.vue
+++ b/frontend/src/views/LibraryView.vue
@@ -28,13 +28,28 @@
           </div>
           <div class="modal-body p-0">
             <div class="row g-0 h-100">
-              <div class="col-md-8 d-flex align-items-center justify-content-center bg-black">
+              <div class="col-md-8 d-flex align-items-center justify-content-center bg-black position-relative">
+                <button
+                  v-if="selectedIndex > 0"
+                  class="btn btn-dark position-absolute top-50 start-0 translate-middle-y opacity-50"
+                  @click="prevImage"
+                >
+                  <i class="bi bi-chevron-left fs-1"></i>
+                </button>
                 <img
                   v-if="selectedImage"
                   :src="apiBase + '/api/images/' + selectedImage.id + '/file?sha=' + selectedImage.sha256"
                   class="img-fluid"
                   :alt="selectedImage.fileName"
+                  style="max-height: 100vh; width: auto;"
                 />
+                <button
+                  v-if="selectedIndex < items.length - 1"
+                  class="btn btn-dark position-absolute top-50 end-0 translate-middle-y opacity-50"
+                  @click="nextImage"
+                >
+                  <i class="bi bi-chevron-right fs-1"></i>
+                </button>
               </div>
               <div class="col-md-4 overflow-auto p-3" v-if="selectedImage">
                 <div class="d-flex justify-content-end mb-3">
@@ -42,6 +57,7 @@
                 </div>
                 <MetadataPanel
                   v-if="metadataEditing"
+                  ref="metadataPanelRef"
                   :image="selectedImage"
                   @saved="onMetadataSaved"
                   @cancel="metadataEditing = false"
@@ -60,8 +76,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
-import { listImages, scanLibrary, getLibraryPath, getImage, deleteImage, apiBase } from '../api'
+import { ref, watchEffect, watch, onUnmounted } from 'vue'
+import { listImages, scanLibrary, getLibraryPath, getImage, deleteImage, updateImageMetadata, apiBase } from '../api'
 import SidebarFilters from '../components/SidebarFilters.vue'
 import ImageGrid from '../components/ImageGrid.vue'
 import Pager from '../components/Pager.vue'
@@ -81,6 +97,8 @@ const total = ref(0)
 const metadataOpen = ref(false)
 const selectedImage = ref<any|null>(null)
 const metadataEditing = ref(false)
+const selectedIndex = ref(-1)
+const metadataPanelRef = ref<any>(null)
 const reloadKey = ref(0)
 
 function reload() {
@@ -107,15 +125,47 @@ function onDeleted(id: number) {
 }
 
 async function onMetadata(img: any) {
-  selectedImage.value = await getImage(img.id)
-  metadataOpen.value = true
-  metadataEditing.value = false
+  const idx = items.value.findIndex(i => i.id === img.id)
+  await showImageAt(idx)
 }
 
 function closeMetadata() {
   metadataOpen.value = false
   selectedImage.value = null
   metadataEditing.value = false
+  selectedIndex.value = -1
+}
+
+async function showImageAt(idx: number) {
+  if (idx < 0 || idx >= items.value.length) return
+  selectedIndex.value = idx
+  const img = await getImage(items.value[idx].id)
+  selectedImage.value = img
+  metadataOpen.value = true
+  metadataEditing.value = false
+}
+
+function prevImage() {
+  showImageAt(selectedIndex.value - 1)
+}
+
+function nextImage() {
+  showImageAt(selectedIndex.value + 1)
+}
+
+async function toggleNsfw() {
+  if (!selectedImage.value) return
+  const newVal = !selectedImage.value.nsfw
+  await updateImageMetadata(selectedImage.value.id, { nsfw: newVal })
+  selectedImage.value.nsfw = newVal
+  const idx = items.value.findIndex(i => i.id === selectedImage.value?.id)
+  if (idx !== -1) {
+    if ((nsfw.value === 'hide' && newVal) || (nsfw.value === 'only' && !newVal)) {
+      items.value.splice(idx, 1)
+    } else {
+      items.value[idx].nsfw = newVal
+    }
+  }
 }
 
 async function onMetadataSaved() {
@@ -141,6 +191,56 @@ async function onDeleteSelected() {
   items.value = items.value.filter(img => img.id !== selectedImage.value?.id)
   closeMetadata()
 }
+
+function onKeydown(e: KeyboardEvent) {
+  if (!metadataOpen.value) return
+  const tag = (e.target as HTMLElement).tagName
+  if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) return
+  switch (e.key) {
+    case 'ArrowLeft':
+      e.preventDefault()
+      prevImage()
+      break
+    case 'ArrowRight':
+      e.preventDefault()
+      nextImage()
+      break
+    case 'Escape':
+      e.preventDefault()
+      closeMetadata()
+      break
+    case 'f':
+      e.preventDefault()
+      toggleNsfw()
+      break
+    case 'd':
+      e.preventDefault()
+      onDeleteSelected()
+      break
+    case 'e':
+      e.preventDefault()
+      metadataEditing.value = true
+      break
+    case 's':
+      if (metadataEditing.value) {
+        e.preventDefault()
+        metadataPanelRef.value?.save()
+      }
+      break
+  }
+}
+
+watch(metadataOpen, (open) => {
+  if (open) {
+    window.addEventListener('keydown', onKeydown)
+  } else {
+    window.removeEventListener('keydown', onKeydown)
+  }
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', onKeydown)
+})
 
 watchEffect(async () => {
   reloadKey.value


### PR DESCRIPTION
## Summary
- Constrain fullscreen image display to viewport height and add overlay arrows for navigation
- Enable keyboard shortcuts for NSFW toggle, deletion, metadata editing/saving, navigation, and exit
- Expose MetadataPanel save function for programmatic saves

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a3fb1d43e48332996f0066b0360cdb