### PR TITLE
Add filesystem watcher for auto library updates

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.24.5
 
 require (
 	github.com/disintegration/imaging v1.6.2
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.10.1
 	github.com/glebarez/sqlite v1.11.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -16,6 +16,8 @@ github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
 github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
 github.com/gin-contrib/cors v1.7.6 h1:3gQ8GMzs1Ylpf70y8bMw4fVpycXIeX1ZemuSQIsnQQY=

--- a/backend/scan/watcher.go
+++ b/backend/scan/watcher.go
@@ -1,0 +1,69 @@
+package scan
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"gorm.io/gorm"
+)
+
+// StartWatcher monitors the root directory for new or modified images and
+// updates the database accordingly. It runs until the process exits.
+func StartWatcher(root string, gdb *gorm.DB) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Printf("watcher: %v", err)
+		return
+	}
+	defer watcher.Close()
+
+	// Recursively register existing directories
+	filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if werr := watcher.Add(path); werr != nil {
+				log.Printf("watcher add %s: %v", path, werr)
+			}
+		}
+		return nil
+	})
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			if event.Op&(fsnotify.Create|fsnotify.Write) != 0 {
+				fi, err := os.Stat(event.Name)
+				if err == nil && fi.IsDir() {
+					if werr := watcher.Add(event.Name); werr != nil {
+						log.Printf("watcher add %s: %v", event.Name, werr)
+					}
+					continue
+				}
+				ext := strings.ToLower(filepath.Ext(event.Name))
+				switch ext {
+				case ".png", ".jpg", ".jpeg", ".webp":
+					go func(p string) {
+						time.Sleep(500 * time.Millisecond)
+						if _, err := ScanFile(gdb, root, p); err != nil {
+							log.Printf("scan file %s: %v", p, err)
+						}
+					}(event.Name)
+				}
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("watcher error: %v", err)
+		}
+	}
+}

--- a/frontend/src/components/SidebarFilters.vue
+++ b/frontend/src/components/SidebarFilters.vue
@@ -36,7 +36,7 @@
 
         <div class="d-grid gap-2 mt-3">
           <button class="btn btn-primary" @click="apply">Apply</button>
-          <button class="btn btn-secondary" @click="$emit('scan')">Scan Library</button>
+          <button class="btn btn-secondary" @click="$emit('scan')">Rescan Library</button>
         </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- watch library folders and ingest modified image files in real time
- expose ScanFile to process individual images without full walk
- start watcher on backend startup and adjust UI wording

## Testing
- `go test ./...`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a40e644eb88332a15611bd720dc4bb