### PR TITLE
Handle SwarmUI metadata and display resolution

### DIFF
--- a/backend/api/images.go
+++ b/backend/api/images.go
@@ -150,7 +150,7 @@ func listImages(gdb *gorm.DB) gin.HandlerFunc {
 func getImage(gdb *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var m db.Image
-		if err := gdb.Preload("Tags").Preload("UserMeta").Preload("Loras").First(&m, c.Param("id")).Error; err != nil {
+		if err := gdb.Preload("Tags").Preload("UserMeta").Preload("Loras").Preload("Embeddings").First(&m, c.Param("id")).Error; err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 			return
 		}
@@ -199,7 +199,11 @@ func updateMetadata(gdb *gorm.DB) gin.HandlerFunc {
 					}
 					name, _ := obj["name"].(string)
 					hash, _ := obj["hash"].(string)
-					loras = append(loras, db.Lora{Name: name, Hash: hash})
+					var weight *float64
+					if w, ok := obj["weight"].(float64); ok {
+						weight = &w
+					}
+					loras = append(loras, db.Lora{Name: name, Hash: hash, Weight: weight})
 				}
 			}
 		}

--- a/backend/db/migrations.go
+++ b/backend/db/migrations.go
@@ -12,8 +12,8 @@ func ApplyMigrations(gdb *gorm.DB) error {
 		// Pragma & tables
 		"PRAGMA foreign_keys = ON;",
 		`CREATE TABLE IF NOT EXISTS images (
-			id INTEGER PRIMARY KEY,
-			path TEXT UNIQUE NOT NULL,
+                        id INTEGER PRIMARY KEY,
+                        path TEXT UNIQUE NOT NULL,
 			file_name TEXT NOT NULL,
 			ext TEXT NOT NULL,
 			size_bytes INTEGER NOT NULL,
@@ -33,6 +33,12 @@ func ApplyMigrations(gdb *gorm.DB) error {
                         seed TEXT,
                         scheduler TEXT,
                         clip_skip INTEGER,
+                        variation_seed INTEGER,
+                        variation_seed_strength REAL,
+                        aspect_ratio TEXT,
+                        refiner_control_percentage REAL,
+                        refiner_upscale REAL,
+                        refiner_upscale_method TEXT,
                         rating INTEGER DEFAULT 0,
                         nsfw INTEGER DEFAULT 0,
                         hidden INTEGER DEFAULT 0,
@@ -66,6 +72,14 @@ func ApplyMigrations(gdb *gorm.DB) error {
                        image_id INTEGER NOT NULL,
                        name TEXT NOT NULL,
                        hash TEXT,
+                       weight REAL,
+                       FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+               );`,
+		`CREATE TABLE IF NOT EXISTS embeddings (
+                       id INTEGER PRIMARY KEY,
+                       image_id INTEGER NOT NULL,
+                       name TEXT NOT NULL,
+                       hash TEXT,
                        FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
                );`,
 		// Indexes
@@ -75,6 +89,7 @@ func ApplyMigrations(gdb *gorm.DB) error {
 		`CREATE INDEX IF NOT EXISTS image_tags_image_idx ON image_tags(image_id);`,
 		`CREATE INDEX IF NOT EXISTS image_tags_tag_idx ON image_tags(tag_id);`,
 		`CREATE INDEX IF NOT EXISTS loras_image_idx ON loras(image_id);`,
+		`CREATE INDEX IF NOT EXISTS embeddings_image_idx ON embeddings(image_id);`,
 		// FTS5 virtual table (content-linked)
 		`CREATE VIRTUAL TABLE IF NOT EXISTS images_fts USING fts5(
 			file_name, model_name, prompt, negative_prompt, raw_metadata,

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -18,17 +18,23 @@ type Image struct {
 	CreatedTime *time.Time `json:"createdTime"`
 	ImportedAt  time.Time  `gorm:"autoCreateTime" json:"importedAt"`
 
-	SourceApp      *string  `json:"sourceApp"`
-	ModelName      *string  `json:"modelName"`
-	ModelHash      *string  `json:"modelHash"`
-	Prompt         *string  `json:"prompt"`
-	NegativePrompt *string  `json:"negativePrompt"`
-	Sampler        *string  `json:"sampler"`
-	Steps          *int     `json:"steps"`
-	CFGScale       *float64 `json:"cfgScale"`
-	Seed           *string  `json:"seed"`
-	Scheduler      *string  `json:"scheduler"`
-	ClipSkip       *int     `json:"clipSkip"`
+	SourceApp                *string  `json:"sourceApp"`
+	ModelName                *string  `json:"modelName"`
+	ModelHash                *string  `json:"modelHash"`
+	Prompt                   *string  `json:"prompt"`
+	NegativePrompt           *string  `json:"negativePrompt"`
+	Sampler                  *string  `json:"sampler"`
+	Steps                    *int     `json:"steps"`
+	CFGScale                 *float64 `json:"cfgScale"`
+	Seed                     *string  `json:"seed"`
+	Scheduler                *string  `json:"scheduler"`
+	ClipSkip                 *int     `json:"clipSkip"`
+	VariationSeed            *int     `json:"variationSeed"`
+	VariationSeedStrength    *float64 `json:"variationSeedStrength"`
+	AspectRatio              *string  `json:"aspectRatio"`
+	RefinerControlPercentage *float64 `json:"refinerControlPercentage"`
+	RefinerUpscale           *float64 `json:"refinerUpscale"`
+	RefinerUpscaleMethod     *string  `json:"refinerUpscaleMethod"`
 
 	Rating int  `gorm:"default:0" json:"rating"`
 	NSFW   bool `gorm:"default:false" json:"nsfw"`
@@ -36,9 +42,10 @@ type Image struct {
 
 	RawMetadata datatypes.JSON `json:"rawMetadata"`
 
-	Loras    []Lora         `gorm:"constraint:OnDelete:CASCADE" json:"loras"`
-	Tags     []*Tag         `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
-	UserMeta []UserMetadata `gorm:"constraint:OnDelete:CASCADE" json:"userMeta"`
+	Loras      []Lora         `gorm:"constraint:OnDelete:CASCADE" json:"loras"`
+	Embeddings []Embedding    `gorm:"constraint:OnDelete:CASCADE" json:"embeddings"`
+	Tags       []*Tag         `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
+	UserMeta   []UserMetadata `gorm:"constraint:OnDelete:CASCADE" json:"userMeta"`
 }
 
 type Tag struct {
@@ -52,6 +59,14 @@ type ImageTag struct {
 }
 
 type Lora struct {
+	ID      uint     `gorm:"primaryKey" json:"id"`
+	ImageID uint     `gorm:"index;not null" json:"imageId"`
+	Name    string   `json:"name"`
+	Hash    string   `json:"hash"`
+	Weight  *float64 `json:"weight"`
+}
+
+type Embedding struct {
 	ID      uint   `gorm:"primaryKey" json:"id"`
 	ImageID uint   `gorm:"index;not null" json:"imageId"`
 	Name    string `json:"name"`

--- a/frontend/src/components/MetadataDisplay.vue
+++ b/frontend/src/components/MetadataDisplay.vue
@@ -11,6 +11,10 @@
     </div>
     <p><strong>Model:</strong> {{ props.image.modelName }}</p>
     <p><strong>Model Hash:</strong> {{ props.image.modelHash }}</p>
+    <p>
+      <strong>Resolution:</strong>
+      {{ props.image.width }}x{{ props.image.height }}
+    </p>
     <p><strong>NSFW:</strong> {{ props.image.nsfw ? "Yes" : "No" }}</p>
     <div>
       <strong>Loras:</strong>

--- a/frontend/src/components/MetadataDisplay.vue
+++ b/frontend/src/components/MetadataDisplay.vue
@@ -20,7 +20,18 @@
       <strong>Loras:</strong>
       <div v-if="props.image.loras && props.image.loras.length">
         <div v-for="(l, i) in props.image.loras" :key="i">
-          {{ l.name }} ({{ l.hash }})
+          {{ l.name }} ({{ l.hash }}<span v-if="l.weight !== undefined">, w={{
+            l.weight
+          }}</span>)
+        </div>
+      </div>
+      <div v-else class="text-muted">None</div>
+    </div>
+    <div>
+      <strong>Embeddings:</strong>
+      <div v-if="props.image.embeddings && props.image.embeddings.length">
+        <div v-for="(e, i) in props.image.embeddings" :key="i">
+          {{ e.name }} ({{ e.hash }})
         </div>
       </div>
       <div v-else class="text-muted">None</div>

--- a/frontend/src/components/MetadataPanel.vue
+++ b/frontend/src/components/MetadataPanel.vue
@@ -23,6 +23,12 @@
         <input class="form-control" v-model="form.modelHash" />
       </div>
       <div class="mb-3">
+        <label class="form-label">Resolution</label>
+        <p class="form-control-plaintext">
+          {{ props.image.width }}x{{ props.image.height }}
+        </p>
+      </div>
+      <div class="mb-3">
         <label class="form-label">Loras</label>
         <div v-for="(l, i) in loras" :key="i" class="input-group mb-1">
           <input class="form-control" placeholder="Name" v-model="l.name" />

--- a/frontend/src/components/MetadataPanel.vue
+++ b/frontend/src/components/MetadataPanel.vue
@@ -32,6 +32,13 @@
         <label class="form-label">Loras</label>
         <div v-for="(l, i) in loras" :key="i" class="input-group mb-1">
           <input class="form-control" placeholder="Name" v-model="l.name" />
+          <input
+            class="form-control"
+            placeholder="Weight"
+            type="number"
+            step="0.1"
+            v-model.number="l.weight"
+          />
           <input class="form-control" placeholder="Hash" v-model="l.hash" />
           <button
             class="btn btn-outline-danger"
@@ -164,7 +171,7 @@ const form = reactive({
 });
 
 const tags = ref<string[]>([]);
-const loras = ref<{ name: string; hash: string }[]>([]);
+const loras = ref<{ name: string; hash: string; weight?: number }[]>([]);
 const rawOpen = ref(false);
 
 watch(
@@ -185,7 +192,11 @@ watch(
     form.rating = img?.rating ?? 0;
     tags.value = img?.tags?.map((t: any) => t.name) ?? [];
     loras.value =
-      img?.loras?.map((l: any) => ({ name: l.name, hash: l.hash })) ?? [];
+      img?.loras?.map((l: any) => ({
+        name: l.name,
+        hash: l.hash,
+        weight: l.weight,
+      })) ?? [];
     rawOpen.value = false;
   },
   { immediate: true },
@@ -213,7 +224,9 @@ async function onSave() {
     scheduler: form.scheduler || null,
     clipSkip: form.clipSkip !== "" ? Number(form.clipSkip) : null,
     sourceApp: form.sourceApp || null,
-    loras: loras.value.filter((l) => l.name || l.hash),
+    loras: loras.value
+      .filter((l) => l.name || l.hash)
+      .map((l) => ({ name: l.name, hash: l.hash, weight: l.weight })),
     nsfw: form.nsfw,
   };
   await updateImageMetadata(props.image.id, payload);
@@ -221,7 +234,7 @@ async function onSave() {
 }
 
 function addLora() {
-  loras.value.push({ name: "", hash: "" });
+  loras.value.push({ name: "", hash: "", weight: undefined });
 }
 
 function removeLora(i: number) {


### PR DESCRIPTION
## Summary
- Skip `sui_extra_data` and `images` when merging metadata and flag `swarm_version` images as originating from SwarmUI
- Show image resolution in metadata display and editor panels

## Testing
- `go test ./...` *(fails: no test files)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a63b7a499c8332b749c2cbf3b64cbb