### PR TITLE
Remove user metadata support

### DIFF
--- a/backend/api/images.go
+++ b/backend/api/images.go
@@ -150,7 +150,7 @@ func listImages(gdb *gorm.DB) gin.HandlerFunc {
 func getImage(gdb *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var m db.Image
-                if err := gdb.Preload("Tags").Preload("Loras").First(&m, c.Param("id")).Error; err != nil {
+		if err := gdb.Preload("Tags").Preload("Loras").Preload("Embeddings").First(&m, c.Param("id")).Error; err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 			return
 		}
@@ -199,7 +199,11 @@ func updateMetadata(gdb *gorm.DB) gin.HandlerFunc {
 					}
 					name, _ := obj["name"].(string)
 					hash, _ := obj["hash"].(string)
-					loras = append(loras, db.Lora{Name: name, Hash: hash})
+					var weight *float64
+					if w, ok := obj["weight"].(float64); ok {
+						weight = &w
+					}
+					loras = append(loras, db.Lora{Name: name, Hash: hash, Weight: weight})
 				}
 			}
 		}

--- a/backend/api/images.go
+++ b/backend/api/images.go
@@ -150,7 +150,7 @@ func listImages(gdb *gorm.DB) gin.HandlerFunc {
 func getImage(gdb *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var m db.Image
-		if err := gdb.Preload("Tags").Preload("UserMeta").Preload("Loras").First(&m, c.Param("id")).Error; err != nil {
+                if err := gdb.Preload("Tags").Preload("Loras").First(&m, c.Param("id")).Error; err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
 			return
 		}

--- a/backend/db/migrations.go
+++ b/backend/db/migrations.go
@@ -12,8 +12,8 @@ func ApplyMigrations(gdb *gorm.DB) error {
 		// Pragma & tables
 		"PRAGMA foreign_keys = ON;",
 		`CREATE TABLE IF NOT EXISTS images (
-			id INTEGER PRIMARY KEY,
-			path TEXT UNIQUE NOT NULL,
+                        id INTEGER PRIMARY KEY,
+                        path TEXT UNIQUE NOT NULL,
 			file_name TEXT NOT NULL,
 			ext TEXT NOT NULL,
 			size_bytes INTEGER NOT NULL,
@@ -33,6 +33,12 @@ func ApplyMigrations(gdb *gorm.DB) error {
                         seed TEXT,
                         scheduler TEXT,
                         clip_skip INTEGER,
+                        variation_seed INTEGER,
+                        variation_seed_strength REAL,
+                        aspect_ratio TEXT,
+                        refiner_control_percentage REAL,
+                        refiner_upscale REAL,
+                        refiner_upscale_method TEXT,
                         rating INTEGER DEFAULT 0,
                         nsfw INTEGER DEFAULT 0,
                         hidden INTEGER DEFAULT 0,
@@ -58,6 +64,14 @@ func ApplyMigrations(gdb *gorm.DB) error {
                        image_id INTEGER NOT NULL,
                        name TEXT NOT NULL,
                        hash TEXT,
+                       weight REAL,
+                       FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+               );`,
+		`CREATE TABLE IF NOT EXISTS embeddings (
+                       id INTEGER PRIMARY KEY,
+                       image_id INTEGER NOT NULL,
+                       name TEXT NOT NULL,
+                       hash TEXT,
                        FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
                );`,
 		// Indexes
@@ -67,6 +81,7 @@ func ApplyMigrations(gdb *gorm.DB) error {
 		`CREATE INDEX IF NOT EXISTS image_tags_image_idx ON image_tags(image_id);`,
 		`CREATE INDEX IF NOT EXISTS image_tags_tag_idx ON image_tags(tag_id);`,
 		`CREATE INDEX IF NOT EXISTS loras_image_idx ON loras(image_id);`,
+		`CREATE INDEX IF NOT EXISTS embeddings_image_idx ON embeddings(image_id);`,
 		// FTS5 virtual table (content-linked)
 		`CREATE VIRTUAL TABLE IF NOT EXISTS images_fts USING fts5(
 			file_name, model_name, prompt, negative_prompt, raw_metadata,

--- a/backend/db/migrations.go
+++ b/backend/db/migrations.go
@@ -49,14 +49,6 @@ func ApplyMigrations(gdb *gorm.DB) error {
 			FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
 			FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE CASCADE
 		);`,
-		`CREATE TABLE IF NOT EXISTS user_metadata (
-                        id INTEGER PRIMARY KEY,
-                        image_id INTEGER NOT NULL,
-                        key TEXT NOT NULL,
-                        value TEXT NOT NULL,
-                        UNIQUE(image_id, key),
-                        FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
-                );`,
 		`CREATE TABLE IF NOT EXISTS settings (
                        key TEXT PRIMARY KEY,
                        value TEXT NOT NULL

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -18,17 +18,23 @@ type Image struct {
 	CreatedTime *time.Time `json:"createdTime"`
 	ImportedAt  time.Time  `gorm:"autoCreateTime" json:"importedAt"`
 
-	SourceApp      *string  `json:"sourceApp"`
-	ModelName      *string  `json:"modelName"`
-	ModelHash      *string  `json:"modelHash"`
-	Prompt         *string  `json:"prompt"`
-	NegativePrompt *string  `json:"negativePrompt"`
-	Sampler        *string  `json:"sampler"`
-	Steps          *int     `json:"steps"`
-	CFGScale       *float64 `json:"cfgScale"`
-	Seed           *string  `json:"seed"`
-	Scheduler      *string  `json:"scheduler"`
-	ClipSkip       *int     `json:"clipSkip"`
+	SourceApp                *string  `json:"sourceApp"`
+	ModelName                *string  `json:"modelName"`
+	ModelHash                *string  `json:"modelHash"`
+	Prompt                   *string  `json:"prompt"`
+	NegativePrompt           *string  `json:"negativePrompt"`
+	Sampler                  *string  `json:"sampler"`
+	Steps                    *int     `json:"steps"`
+	CFGScale                 *float64 `json:"cfgScale"`
+	Seed                     *string  `json:"seed"`
+	Scheduler                *string  `json:"scheduler"`
+	ClipSkip                 *int     `json:"clipSkip"`
+	VariationSeed            *int     `json:"variationSeed"`
+	VariationSeedStrength    *float64 `json:"variationSeedStrength"`
+	AspectRatio              *string  `json:"aspectRatio"`
+	RefinerControlPercentage *float64 `json:"refinerControlPercentage"`
+	RefinerUpscale           *float64 `json:"refinerUpscale"`
+	RefinerUpscaleMethod     *string  `json:"refinerUpscaleMethod"`
 
 	Rating int  `gorm:"default:0" json:"rating"`
 	NSFW   bool `gorm:"default:false" json:"nsfw"`
@@ -36,8 +42,9 @@ type Image struct {
 
 	RawMetadata datatypes.JSON `json:"rawMetadata"`
 
-        Loras []Lora `gorm:"constraint:OnDelete:CASCADE" json:"loras"`
-        Tags  []*Tag `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
+	Loras      []Lora      `gorm:"constraint:OnDelete:CASCADE" json:"loras"`
+	Embeddings []Embedding `gorm:"constraint:OnDelete:CASCADE" json:"embeddings"`
+	Tags       []*Tag      `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
 }
 
 type Tag struct {
@@ -51,10 +58,18 @@ type ImageTag struct {
 }
 
 type Lora struct {
-        ID      uint   `gorm:"primaryKey" json:"id"`
-        ImageID uint   `gorm:"index;not null" json:"imageId"`
-        Name    string `json:"name"`
-        Hash    string `json:"hash"`
+	ID      uint     `gorm:"primaryKey" json:"id"`
+	ImageID uint     `gorm:"index;not null" json:"imageId"`
+	Name    string   `json:"name"`
+	Hash    string   `json:"hash"`
+	Weight  *float64 `json:"weight"`
+}
+
+type Embedding struct {
+	ID      uint   `gorm:"primaryKey" json:"id"`
+	ImageID uint   `gorm:"index;not null" json:"imageId"`
+	Name    string `json:"name"`
+	Hash    string `json:"hash"`
 }
 
 type Setting struct {

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -36,9 +36,8 @@ type Image struct {
 
 	RawMetadata datatypes.JSON `json:"rawMetadata"`
 
-	Loras    []Lora         `gorm:"constraint:OnDelete:CASCADE" json:"loras"`
-	Tags     []*Tag         `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
-	UserMeta []UserMetadata `gorm:"constraint:OnDelete:CASCADE" json:"userMeta"`
+        Loras []Lora `gorm:"constraint:OnDelete:CASCADE" json:"loras"`
+        Tags  []*Tag `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
 }
 
 type Tag struct {
@@ -52,17 +51,10 @@ type ImageTag struct {
 }
 
 type Lora struct {
-	ID      uint   `gorm:"primaryKey" json:"id"`
-	ImageID uint   `gorm:"index;not null" json:"imageId"`
-	Name    string `json:"name"`
-	Hash    string `json:"hash"`
-}
-
-type UserMetadata struct {
-	ID      uint   `gorm:"primaryKey" json:"id"`
-	ImageID uint   `gorm:"index;not null" json:"imageId"`
-	Key     string `gorm:"not null" json:"key"`
-	Value   string `gorm:"not null" json:"value"`
+        ID      uint   `gorm:"primaryKey" json:"id"`
+        ImageID uint   `gorm:"index;not null" json:"imageId"`
+        Name    string `json:"name"`
+        Hash    string `json:"hash"`
 }
 
 type Setting struct {

--- a/backend/scan/scanner.go
+++ b/backend/scan/scanner.go
@@ -140,8 +140,20 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 	// Parse generation parameters if present
 	normalizeParameters(metaMap)
 
-	// Extract model hash and any loras from sui_models
-	modelHash, loras := extractModels(metaMap)
+	// Extract model hash, loras, and embeddings from sui_models
+	modelHash, loras, embeds := extractModels(metaMap)
+	if ws, ok := metaMap["loraweights"]; ok {
+		var arr []string
+		if json.Unmarshal([]byte(ws), &arr) == nil {
+			for i := range loras {
+				if i < len(arr) {
+					if fv, err := strconv.ParseFloat(arr[i], 64); err == nil {
+						loras[i].Weight = &fv
+					}
+				}
+			}
+		}
+	}
 	if modelHash != "" && metaMap["model hash"] == "" {
 		metaMap["model hash"] = modelHash
 	}
@@ -154,13 +166,14 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 	rel = filepath.ToSlash(rel)
 
 	img := db.Image{
-		Path:      rel,
-		FileName:  dName(path),
-		Ext:       strings.TrimPrefix(ext, "."),
-		SizeBytes: size,
-		SHA256:    sha,
-		NSFW:      checkNSFW(metaMap, dName(path)),
-		Loras:     loras,
+		Path:       rel,
+		FileName:   dName(path),
+		Ext:        strings.TrimPrefix(ext, "."),
+		SizeBytes:  size,
+		SHA256:     sha,
+		NSFW:       checkNSFW(metaMap, dName(path)),
+		Loras:      loras,
+		Embeddings: embeds,
 	}
 	if width > 0 {
 		img.Width = &width
@@ -212,6 +225,32 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 		if iv, err := strconv.Atoi(v); err == nil {
 			img.ClipSkip = &iv
 		}
+	}
+	if v, ok := metaMap["variationseed"]; ok {
+		if iv, err := strconv.Atoi(v); err == nil {
+			img.VariationSeed = &iv
+		}
+	}
+	if v, ok := metaMap["variationseedstrength"]; ok {
+		if fv, err := strconv.ParseFloat(v, 64); err == nil {
+			img.VariationSeedStrength = &fv
+		}
+	}
+	if v, ok := metaMap["aspectratio"]; ok {
+		img.AspectRatio = &v
+	}
+	if v, ok := metaMap["refinercontrolpercentage"]; ok {
+		if fv, err := strconv.ParseFloat(v, 64); err == nil {
+			img.RefinerControlPercentage = &fv
+		}
+	}
+	if v, ok := metaMap["refinerupscale"]; ok {
+		if fv, err := strconv.ParseFloat(v, 64); err == nil {
+			img.RefinerUpscale = &fv
+		}
+	}
+	if v, ok := metaMap["refinerupscalemethod"]; ok {
+		img.RefinerUpscaleMethod = &v
 	}
 
 	// Store raw metadata JSON
@@ -463,18 +502,32 @@ func mergeJSONMeta(meta map[string]string) {
 		"clip_skip":       "clip skip",
 	}
 
+	// Keys to exclude entirely from the metadata map.
+	exclude := map[string]struct{}{
+		"sui_extra_data": {},
+		"images":         {},
+	}
+
 	// Keep parsing as long as we keep discovering new JSON blobs.
 	for {
 		changed := false
-		for _, v := range meta {
+		for k, v := range meta {
+			if _, skip := exclude[k]; skip {
+				delete(meta, k)
+				changed = true
+				continue
+			}
 			v = strings.TrimSpace(v)
 			if v == "" {
 				continue
 			}
 			var obj map[string]any
 			if json.Unmarshal([]byte(v), &obj) == nil {
-				for k, val := range obj {
-					key := strings.ToLower(k)
+				for kk, val := range obj {
+					key := strings.ToLower(kk)
+					if _, skip := exclude[key]; skip {
+						continue
+					}
 					if alias, ok := aliases[key]; ok {
 						key = alias
 					}
@@ -503,6 +556,13 @@ func mergeJSONMeta(meta map[string]string) {
 		}
 		if !changed {
 			break
+		}
+	}
+
+	// Set Source App for SwarmUI metadata
+	if _, ok := meta["swarm_version"]; ok {
+		if cur, ok := meta["sourceapp"]; !ok || cur == "" {
+			meta["sourceapp"] = "SwarmUI"
 		}
 	}
 }
@@ -551,12 +611,12 @@ func normalizeParameters(meta map[string]string) {
 	}
 }
 
-// extractModels parses the sui_models JSON array and returns the model hash and
-// any loras used by the generation. Loras are returned as a slice of db.Lora.
-func extractModels(meta map[string]string) (string, []db.Lora) {
+// extractModels parses the sui_models JSON array and returns the model hash,
+// any loras, and any embeddings used by the generation.
+func extractModels(meta map[string]string) (string, []db.Lora, []db.Embedding) {
 	s, ok := meta["sui_models"]
 	if !ok {
-		return "", nil
+		return "", nil, nil
 	}
 	var entries []struct {
 		Name  string `json:"name"`
@@ -564,12 +624,16 @@ func extractModels(meta map[string]string) (string, []db.Lora) {
 		Hash  string `json:"hash"`
 	}
 	if err := json.Unmarshal([]byte(s), &entries); err != nil {
-		return "", nil
+		return "", nil, nil
 	}
 	var modelHash string
 	loras := []db.Lora{}
+	embeds := []db.Embedding{}
 	for _, e := range entries {
 		name := strings.TrimSuffix(e.Name, ".safetensors")
+		if strings.HasPrefix(name, "LyCORIS/") {
+			name = strings.TrimPrefix(name, "LyCORIS/")
+		}
 		switch e.Param {
 		case "model":
 			if e.Hash != "" {
@@ -582,9 +646,13 @@ func extractModels(meta map[string]string) (string, []db.Lora) {
 			if name != "" || e.Hash != "" {
 				loras = append(loras, db.Lora{Name: name, Hash: e.Hash})
 			}
+		case "used_embeddings":
+			if name != "" || e.Hash != "" {
+				embeds = append(embeds, db.Embedding{Name: name, Hash: e.Hash})
+			}
 		}
 	}
-	return modelHash, loras
+	return modelHash, loras, embeds
 }
 
 // checkNSFW applies a simple keyword heuristic on prompts and file name.

--- a/frontend/src/components/MetadataDisplay.vue
+++ b/frontend/src/components/MetadataDisplay.vue
@@ -11,12 +11,27 @@
     </div>
     <p><strong>Model:</strong> {{ props.image.modelName }}</p>
     <p><strong>Model Hash:</strong> {{ props.image.modelHash }}</p>
+    <p>
+      <strong>Resolution:</strong>
+      {{ props.image.width }}x{{ props.image.height }}
+    </p>
     <p><strong>NSFW:</strong> {{ props.image.nsfw ? "Yes" : "No" }}</p>
     <div>
       <strong>Loras:</strong>
       <div v-if="props.image.loras && props.image.loras.length">
         <div v-for="(l, i) in props.image.loras" :key="i">
-          {{ l.name }} ({{ l.hash }})
+          {{ l.name }} ({{ l.hash }}<span v-if="l.weight !== undefined">, w={{
+            l.weight
+          }}</span>)
+        </div>
+      </div>
+      <div v-else class="text-muted">None</div>
+    </div>
+    <div>
+      <strong>Embeddings:</strong>
+      <div v-if="props.image.embeddings && props.image.embeddings.length">
+        <div v-for="(e, i) in props.image.embeddings" :key="i">
+          {{ e.name }} ({{ e.hash }})
         </div>
       </div>
       <div v-else class="text-muted">None</div>

--- a/frontend/src/components/MetadataPanel.vue
+++ b/frontend/src/components/MetadataPanel.vue
@@ -23,9 +23,22 @@
         <input class="form-control" v-model="form.modelHash" />
       </div>
       <div class="mb-3">
+        <label class="form-label">Resolution</label>
+        <p class="form-control-plaintext">
+          {{ props.image.width }}x{{ props.image.height }}
+        </p>
+      </div>
+      <div class="mb-3">
         <label class="form-label">Loras</label>
         <div v-for="(l, i) in loras" :key="i" class="input-group mb-1">
           <input class="form-control" placeholder="Name" v-model="l.name" />
+          <input
+            class="form-control"
+            placeholder="Weight"
+            type="number"
+            step="0.1"
+            v-model.number="l.weight"
+          />
           <input class="form-control" placeholder="Hash" v-model="l.hash" />
           <button
             class="btn btn-outline-danger"
@@ -158,7 +171,7 @@ const form = reactive({
 });
 
 const tags = ref<string[]>([]);
-const loras = ref<{ name: string; hash: string }[]>([]);
+const loras = ref<{ name: string; hash: string; weight?: number }[]>([]);
 const rawOpen = ref(false);
 
 watch(
@@ -179,7 +192,11 @@ watch(
     form.rating = img?.rating ?? 0;
     tags.value = img?.tags?.map((t: any) => t.name) ?? [];
     loras.value =
-      img?.loras?.map((l: any) => ({ name: l.name, hash: l.hash })) ?? [];
+      img?.loras?.map((l: any) => ({
+        name: l.name,
+        hash: l.hash,
+        weight: l.weight,
+      })) ?? [];
     rawOpen.value = false;
   },
   { immediate: true },
@@ -207,7 +224,9 @@ async function onSave() {
     scheduler: form.scheduler || null,
     clipSkip: form.clipSkip !== "" ? Number(form.clipSkip) : null,
     sourceApp: form.sourceApp || null,
-    loras: loras.value.filter((l) => l.name || l.hash),
+    loras: loras.value
+      .filter((l) => l.name || l.hash)
+      .map((l) => ({ name: l.name, hash: l.hash, weight: l.weight })),
     nsfw: form.nsfw,
   };
   await updateImageMetadata(props.image.id, payload);
@@ -215,7 +234,7 @@ async function onSave() {
 }
 
 function addLora() {
-  loras.value.push({ name: "", hash: "" });
+  loras.value.push({ name: "", hash: "", weight: undefined });
 }
 
 function removeLora(i: number) {


### PR DESCRIPTION
## Summary
- drop creation of obsolete user_metadata table in database migrations
- remove UserMeta associations and UserMetadata model
- stop preloading user metadata when fetching images

## Testing
- `go test ./...`
- `go build ./...`
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a67f82d8048332975379acfe40498b