### PR TITLE
Support name-based Lora lookup with hash conflict detection

### DIFF
--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -42,7 +42,7 @@ type Image struct {
 
 	RawMetadata datatypes.JSON `json:"rawMetadata"`
 
-	Loras      []Lora         `gorm:"constraint:OnDelete:CASCADE" json:"loras"`
+	Loras      []*Lora        `gorm:"many2many:image_loras;constraint:OnDelete:CASCADE" json:"loras"`
 	Embeddings []Embedding    `gorm:"constraint:OnDelete:CASCADE" json:"embeddings"`
 	Tags       []*Tag         `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
 	UserMeta   []UserMetadata `gorm:"constraint:OnDelete:CASCADE" json:"userMeta"`
@@ -58,12 +58,15 @@ type ImageTag struct {
 	TagID   uint `gorm:"primaryKey" json:"tagId"`
 }
 
+type ImageLora struct {
+	ImageID uint `gorm:"primaryKey" json:"imageId"`
+	LoraID  uint `gorm:"primaryKey" json:"loraId"`
+}
+
 type Lora struct {
-	ID      uint     `gorm:"primaryKey" json:"id"`
-	ImageID uint     `gorm:"index;not null" json:"imageId"`
-	Name    string   `json:"name"`
-	Hash    string   `json:"hash"`
-	Weight  *float64 `json:"weight"`
+	ID   uint    `gorm:"primaryKey" json:"id"`
+	Name string  `gorm:"uniqueIndex;not null" json:"name"`
+	Hash *string `gorm:"index" json:"hash"`
 }
 
 type Embedding struct {


### PR DESCRIPTION
## Summary
- make Lora names unique and hashes optional
- record loras by name and warn on hash conflicts in scanner and API
- index lora hashes for faster duplicate detection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6822ae4048332b36e4ac828f85383