### PR TITLE
Deduplicate embeddings and index by hash

### DIFF
--- a/backend/db/migrations.go
+++ b/backend/db/migrations.go
@@ -72,12 +72,18 @@ func ApplyMigrations(gdb *gorm.DB) error {
                        FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
                        FOREIGN KEY (lora_id) REFERENCES loras(id) ON DELETE CASCADE
                );`,
+		`DROP TABLE IF EXISTS embeddings;`,
 		`CREATE TABLE IF NOT EXISTS embeddings (
                        id INTEGER PRIMARY KEY,
+                       name TEXT UNIQUE NOT NULL,
+                       hash TEXT
+               );`,
+		`CREATE TABLE IF NOT EXISTS image_embeddings (
                        image_id INTEGER NOT NULL,
-                       name TEXT NOT NULL,
-                       hash TEXT,
-                       FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
+                       embedding_id INTEGER NOT NULL,
+                       PRIMARY KEY (image_id, embedding_id),
+                       FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
+                       FOREIGN KEY (embedding_id) REFERENCES embeddings(id) ON DELETE CASCADE
                );`,
 		`ALTER TABLE loras DROP COLUMN image_id;`,
 		// Indexes
@@ -89,7 +95,9 @@ func ApplyMigrations(gdb *gorm.DB) error {
 		`CREATE INDEX IF NOT EXISTS loras_hash_idx ON loras(hash);`,
 		`CREATE INDEX IF NOT EXISTS image_loras_image_idx ON image_loras(image_id);`,
 		`CREATE INDEX IF NOT EXISTS image_loras_lora_idx ON image_loras(lora_id);`,
-		`CREATE INDEX IF NOT EXISTS embeddings_image_idx ON embeddings(image_id);`,
+		`CREATE INDEX IF NOT EXISTS embeddings_hash_idx ON embeddings(hash);`,
+		`CREATE INDEX IF NOT EXISTS image_embeddings_image_idx ON image_embeddings(image_id);`,
+		`CREATE INDEX IF NOT EXISTS image_embeddings_embedding_idx ON image_embeddings(embedding_id);`,
 		// FTS5 virtual table (content-linked)
 		`CREATE VIRTUAL TABLE IF NOT EXISTS images_fts USING fts5(
 			file_name, model_name, prompt, negative_prompt, raw_metadata,

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -42,9 +42,9 @@ type Image struct {
 
 	RawMetadata datatypes.JSON `json:"rawMetadata"`
 
-	Loras      []*Lora     `gorm:"many2many:image_loras;constraint:OnDelete:CASCADE" json:"loras"`
-	Embeddings []Embedding `gorm:"constraint:OnDelete:CASCADE" json:"embeddings"`
-	Tags       []*Tag      `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
+	Loras      []*Lora      `gorm:"many2many:image_loras;constraint:OnDelete:CASCADE" json:"loras"`
+	Embeddings []*Embedding `gorm:"many2many:image_embeddings;constraint:OnDelete:CASCADE" json:"embeddings"`
+	Tags       []*Tag       `gorm:"many2many:image_tags;constraint:OnDelete:CASCADE" json:"tags"`
 }
 
 type Tag struct {
@@ -62,6 +62,11 @@ type ImageLora struct {
 	LoraID  uint `gorm:"primaryKey" json:"loraId"`
 }
 
+type ImageEmbedding struct {
+	ImageID     uint `gorm:"primaryKey" json:"imageId"`
+	EmbeddingID uint `gorm:"primaryKey" json:"embeddingId"`
+}
+
 type Lora struct {
 	ID   uint    `gorm:"primaryKey" json:"id"`
 	Name string  `gorm:"uniqueIndex;not null" json:"name"`
@@ -69,10 +74,9 @@ type Lora struct {
 }
 
 type Embedding struct {
-	ID      uint   `gorm:"primaryKey" json:"id"`
-	ImageID uint   `gorm:"index;not null" json:"imageId"`
-	Name    string `json:"name"`
-	Hash    string `json:"hash"`
+	ID   uint    `gorm:"primaryKey" json:"id"`
+	Name string  `gorm:"uniqueIndex;not null" json:"name"`
+	Hash *string `gorm:"index" json:"hash"`
 }
 
 type Setting struct {


### PR DESCRIPTION
## Summary
- Store embeddings in their own table with unique names and hash index
- Add image_embeddings join table and association logic
- Deduplicate embeddings during scan using name and hash

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a731fa272c833284a5cdd9a704b517