### PR TITLE
Refactor model handling and store LoRA weights

### DIFF
--- a/backend/db/migrations.go
+++ b/backend/db/migrations.go
@@ -12,24 +12,28 @@ func ApplyMigrations(gdb *gorm.DB) error {
 	stmts := []string{
 		// Pragma & tables
 		"PRAGMA foreign_keys = ON;",
+		`CREATE TABLE IF NOT EXISTS models (
+                       id INTEGER PRIMARY KEY,
+                       name TEXT UNIQUE NOT NULL,
+                       hash TEXT
+               );`,
 		`CREATE TABLE IF NOT EXISTS images (
                         id INTEGER PRIMARY KEY,
                         path TEXT UNIQUE NOT NULL,
-			file_name TEXT NOT NULL,
-			ext TEXT NOT NULL,
-			size_bytes INTEGER NOT NULL,
-			sha256 TEXT UNIQUE NOT NULL,
-			width INTEGER,
-			height INTEGER,
-			created_time DATETIME,
-			imported_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-			source_app TEXT,
-			model_name TEXT,
-			model_hash TEXT,
-			prompt TEXT,
-			negative_prompt TEXT,
-			sampler TEXT,
-			steps INTEGER,
+                        file_name TEXT NOT NULL,
+                        ext TEXT NOT NULL,
+                        size_bytes INTEGER NOT NULL,
+                        sha256 TEXT UNIQUE NOT NULL,
+                        width INTEGER,
+                        height INTEGER,
+                        created_time DATETIME,
+                        imported_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                        source_app TEXT,
+                        model_id INTEGER,
+                        prompt TEXT,
+                        negative_prompt TEXT,
+                        sampler TEXT,
+                        steps INTEGER,
                         cfg_scale REAL,
                         seed TEXT,
                         scheduler TEXT,
@@ -43,7 +47,8 @@ func ApplyMigrations(gdb *gorm.DB) error {
                         rating INTEGER DEFAULT 0,
                         nsfw INTEGER DEFAULT 0,
                         hidden INTEGER DEFAULT 0,
-                        raw_metadata TEXT
+                        raw_metadata TEXT,
+                        FOREIGN KEY (model_id) REFERENCES models(id)
                 );`,
 		`CREATE TABLE IF NOT EXISTS tags (
 			id INTEGER PRIMARY KEY,
@@ -68,6 +73,7 @@ func ApplyMigrations(gdb *gorm.DB) error {
 		`CREATE TABLE IF NOT EXISTS image_loras (
                        image_id INTEGER NOT NULL,
                        lora_id INTEGER NOT NULL,
+                       weight REAL,
                        PRIMARY KEY (image_id, lora_id),
                        FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
                        FOREIGN KEY (lora_id) REFERENCES loras(id) ON DELETE CASCADE
@@ -86,10 +92,15 @@ func ApplyMigrations(gdb *gorm.DB) error {
                        FOREIGN KEY (embedding_id) REFERENCES embeddings(id) ON DELETE CASCADE
                );`,
 		`ALTER TABLE loras DROP COLUMN image_id;`,
+		`ALTER TABLE image_loras ADD COLUMN weight REAL;`,
+		`ALTER TABLE images ADD COLUMN model_id INTEGER;`,
+		`ALTER TABLE images DROP COLUMN model_name;`,
+		`ALTER TABLE images DROP COLUMN model_hash;`,
 		// Indexes
 		`CREATE INDEX IF NOT EXISTS images_nsfw_idx ON images(nsfw);`,
 		`CREATE INDEX IF NOT EXISTS images_rating_idx ON images(rating);`,
-		`CREATE INDEX IF NOT EXISTS images_model_idx ON images(model_name);`,
+		`CREATE INDEX IF NOT EXISTS images_model_idx ON images(model_id);`,
+		`CREATE INDEX IF NOT EXISTS models_hash_idx ON models(hash);`,
 		`CREATE INDEX IF NOT EXISTS image_tags_image_idx ON image_tags(image_id);`,
 		`CREATE INDEX IF NOT EXISTS image_tags_tag_idx ON image_tags(tag_id);`,
 		`CREATE INDEX IF NOT EXISTS loras_hash_idx ON loras(hash);`,
@@ -105,22 +116,25 @@ func ApplyMigrations(gdb *gorm.DB) error {
 		);`,
 		// Triggers to sync FTS
 		`CREATE TRIGGER IF NOT EXISTS images_ai AFTER INSERT ON images BEGIN
-			INSERT INTO images_fts(rowid, file_name, model_name, prompt, negative_prompt, raw_metadata)
-			VALUES (new.id, new.file_name, new.model_name, new.prompt, new.negative_prompt, new.raw_metadata);
-		END;`,
+                        INSERT INTO images_fts(rowid, file_name, model_name, prompt, negative_prompt, raw_metadata)
+                        VALUES (new.id, new.file_name, (SELECT name FROM models WHERE id = new.model_id), new.prompt, new.negative_prompt, new.raw_metadata);
+                END;`,
 		`CREATE TRIGGER IF NOT EXISTS images_ad AFTER DELETE ON images BEGIN
 			INSERT INTO images_fts(images_fts, rowid, file_name) VALUES('delete', old.id, old.file_name);
 		END;`,
 		`CREATE TRIGGER IF NOT EXISTS images_au AFTER UPDATE ON images BEGIN
-			INSERT INTO images_fts(images_fts, rowid, file_name) VALUES('delete', old.id, old.file_name);
-			INSERT INTO images_fts(rowid, file_name, model_name, prompt, negative_prompt, raw_metadata)
-			VALUES (new.id, new.file_name, new.model_name, new.prompt, new.negative_prompt, new.raw_metadata);
-		END;`,
+                        INSERT INTO images_fts(images_fts, rowid, file_name) VALUES('delete', old.id, old.file_name);
+                        INSERT INTO images_fts(rowid, file_name, model_name, prompt, negative_prompt, raw_metadata)
+                        VALUES (new.id, new.file_name, (SELECT name FROM models WHERE id = new.model_id), new.prompt, new.negative_prompt, new.raw_metadata);
+                END;`,
 	}
 
 	for _, s := range stmts {
 		if err := gdb.Exec(s).Error; err != nil {
-			if strings.Contains(s, "ALTER TABLE loras DROP COLUMN image_id") && strings.Contains(err.Error(), "no such column") {
+			if (strings.Contains(s, "ALTER TABLE loras DROP COLUMN image_id") || strings.Contains(s, "ALTER TABLE images DROP COLUMN model_name") || strings.Contains(s, "ALTER TABLE images DROP COLUMN model_hash")) && strings.Contains(err.Error(), "no such column") {
+				continue
+			}
+			if (strings.Contains(s, "ALTER TABLE image_loras ADD COLUMN weight") || strings.Contains(s, "ALTER TABLE images ADD COLUMN model_id")) && strings.Contains(err.Error(), "duplicate column") {
 				continue
 			}
 			return fmt.Errorf("migration failed on: %s\nerr: %w", s, err)

--- a/backend/db/models.go
+++ b/backend/db/models.go
@@ -19,8 +19,10 @@ type Image struct {
 	ImportedAt  time.Time  `gorm:"autoCreateTime" json:"importedAt"`
 
 	SourceApp                *string  `json:"sourceApp"`
-	ModelName                *string  `json:"modelName"`
-	ModelHash                *string  `json:"modelHash"`
+	ModelID                  *uint    `json:"modelId"`
+	Model                    *Model   `json:"model"`
+	ModelName                *string  `gorm:"-" json:"modelName,omitempty"`
+	ModelHash                *string  `gorm:"-" json:"modelHash,omitempty"`
 	Prompt                   *string  `json:"prompt"`
 	NegativePrompt           *string  `json:"negativePrompt"`
 	Sampler                  *string  `json:"sampler"`
@@ -58,8 +60,9 @@ type ImageTag struct {
 }
 
 type ImageLora struct {
-	ImageID uint `gorm:"primaryKey" json:"imageId"`
-	LoraID  uint `gorm:"primaryKey" json:"loraId"`
+	ImageID uint     `gorm:"primaryKey" json:"imageId"`
+	LoraID  uint     `gorm:"primaryKey" json:"loraId"`
+	Weight  *float64 `json:"weight"`
 }
 
 type ImageEmbedding struct {
@@ -67,10 +70,17 @@ type ImageEmbedding struct {
 	EmbeddingID uint `gorm:"primaryKey" json:"embeddingId"`
 }
 
-type Lora struct {
+type Model struct {
 	ID   uint    `gorm:"primaryKey" json:"id"`
 	Name string  `gorm:"uniqueIndex;not null" json:"name"`
 	Hash *string `gorm:"index" json:"hash"`
+}
+
+type Lora struct {
+	ID     uint     `gorm:"primaryKey" json:"id"`
+	Name   string   `gorm:"uniqueIndex;not null" json:"name"`
+	Hash   *string  `gorm:"index" json:"hash"`
+	Weight *float64 `gorm:"->;column:weight" json:"weight,omitempty"`
 }
 
 type Embedding struct {

--- a/backend/scan/scanner.go
+++ b/backend/scan/scanner.go
@@ -143,9 +143,22 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 
 	// Extract model hash, loras, and embeddings from sui_models
 	modelHash, loras, embeds := extractModels(metaMap)
-	assocLoras := []*db.Lora{}
+	var loraWeights []float64
+	if wstr, ok := metaMap["loraweights"]; ok {
+		parts := strings.Split(wstr, ",")
+		for _, p := range parts {
+			if fv, err := strconv.ParseFloat(strings.TrimSpace(p), 64); err == nil {
+				loraWeights = append(loraWeights, fv)
+			}
+		}
+	}
+	type loraAssoc struct {
+		l      *db.Lora
+		weight *float64
+	}
+	loraAssocs := []loraAssoc{}
 	assocEmbeds := []*db.Embedding{}
-	for _, lr := range loras {
+	for i, lr := range loras {
 		name := lr.Name
 		hash := ""
 		if lr.Hash != nil {
@@ -196,7 +209,12 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 				}
 			}
 		}
-		assocLoras = append(assocLoras, &l)
+		var weight *float64
+		if i < len(loraWeights) {
+			w := loraWeights[i]
+			weight = &w
+		}
+		loraAssocs = append(loraAssocs, loraAssoc{l: &l, weight: weight})
 	}
 	for _, eb := range embeds {
 		name := eb.Name
@@ -255,6 +273,56 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 		metaMap["model hash"] = modelHash
 	}
 
+	var model *db.Model
+	name, hasName := metaMap["model"]
+	hash := metaMap["model hash"]
+	if hasName || hash != "" {
+		if name != "" {
+			var m db.Model
+			if err := tx.Where("name = ?", name).First(&m).Error; err == nil {
+				model = &m
+			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return false, err
+			}
+		}
+		if model == nil && hash != "" {
+			var m db.Model
+			if err := tx.Where("hash = ?", hash).First(&m).Error; err == nil {
+				model = &m
+			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return false, err
+			}
+		}
+		if model == nil && name != "" {
+			m := db.Model{Name: name}
+			if err := tx.Create(&m).Error; err != nil {
+				return false, err
+			}
+			model = &m
+		}
+		if model != nil && hash != "" {
+			if model.Hash == nil {
+				model.Hash = &hash
+				if err := tx.Save(model).Error; err != nil {
+					return false, err
+				}
+			} else if *model.Hash != hash {
+				var existing db.Model
+				if err := tx.Where("hash = ?", hash).First(&existing).Error; err == nil && existing.ID != model.ID {
+					log.Printf("hash conflict for model %s; using existing %s", name, existing.Name)
+					model = &existing
+				} else if errors.Is(err, gorm.ErrRecordNotFound) {
+					model.Hash = &hash
+					if err := tx.Save(model).Error; err != nil {
+						return false, err
+					}
+				} else if err != nil {
+					return false, err
+				}
+			}
+		}
+	}
+
 	// Prepare Image model
 	rel, err := filepath.Rel(root, path)
 	if err != nil {
@@ -284,12 +352,6 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 	// Normalized fields from metaMap
 	if v, ok := metaMap["sourceapp"]; ok {
 		img.SourceApp = &v
-	}
-	if v, ok := metaMap["model"]; ok {
-		img.ModelName = &v
-	}
-	if v, ok := metaMap["model hash"]; ok {
-		img.ModelHash = &v
 	}
 	if v, ok := metaMap["prompt"]; ok {
 		img.Prompt = &v
@@ -347,6 +409,9 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 	if v, ok := metaMap["refinerupscalemethod"]; ok {
 		img.RefinerUpscaleMethod = &v
 	}
+	if model != nil {
+		img.ModelID = &model.ID
+	}
 
 	// Store raw metadata JSON
 	if len(metaMap) > 0 {
@@ -376,9 +441,12 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 	if err := tx.Create(&img).Error; err != nil {
 		return false, err
 	}
-	if len(assocLoras) > 0 {
-		if err := tx.Model(&img).Association("Loras").Append(assocLoras); err != nil {
-			return false, err
+	if len(loraAssocs) > 0 {
+		for _, la := range loraAssocs {
+			il := db.ImageLora{ImageID: img.ID, LoraID: la.l.ID, Weight: la.weight}
+			if err := tx.Create(&il).Error; err != nil {
+				return false, err
+			}
 		}
 	}
 	if len(assocEmbeds) > 0 {


### PR DESCRIPTION
## Summary
- Centralize models in dedicated table linked by `model_id`
- Track LoRA weights from metadata and expose on image associations
- Support updating image models via API and adjust migrations accordingly

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a737b8b36883329a7d07afc652afeb