### PR TITLE
Parse LoRA tags from prompts

### DIFF
--- a/backend/scan/scanner_test.go
+++ b/backend/scan/scanner_test.go
@@ -15,3 +15,16 @@ func TestParseLoraWeightsComma(t *testing.T) {
 		t.Fatalf("unexpected weights %v", w)
 	}
 }
+
+func TestExtractPromptLoras(t *testing.T) {
+        res := extractPromptLoras("a <lora:foo:0.5> and <lyco:bar:1>")
+        if len(res) != 2 {
+                t.Fatalf("expected 2 loras, got %d", len(res))
+        }
+        if res[0].name != "foo" || res[0].weight == nil || *res[0].weight != 0.5 {
+                t.Fatalf("unexpected first lora %+v", res[0])
+        }
+        if res[1].name != "bar" || res[1].weight == nil || *res[1].weight != 1 {
+                t.Fatalf("unexpected second lora %+v", res[1])
+        }
+}


### PR DESCRIPTION
## Summary
- extract `<lora:name:weight>` and `<lyco:name:weight>` tags from image prompts during scanning
- ensure referenced LoRA records exist and associate them with images
- cover prompt-based LoRA parsing with unit tests

## Testing
- `go test ./scan -v`


------
https://chatgpt.com/codex/tasks/task_e_68a7d0edad9c8332bbc8a772389a672d