### PR TITLE
feat: configure log level via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # gen-library
 Image organizer for local generation
 
+## Backend configuration
+
+The backend logger can be configured with environment variables:
+
+| Variable   | Description                                            |
+|------------|--------------------------------------------------------|
+| `LOG_LEVEL` | Sets the log verbosity. Accepts `debug`, `info` (default), `warn`, or `error`. |
+
 ## Todo
 
 ### Metadata

--- a/backend/logger/logger.go
+++ b/backend/logger/logger.go
@@ -3,21 +3,47 @@ package logger
 import (
 	"io"
 	"os"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/mattn/go-isatty"
 	"github.com/rs/zerolog"
 )
 
-var l zerolog.Logger
+var (
+	l        zerolog.Logger
+	once     sync.Once
+	logLevel = zerolog.InfoLevel
+)
 
 // Init configures the global logger. It should be called before any logging.
 func Init() {
-	var w io.Writer = os.Stdout
-	if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
-		w = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
-	}
-	l = zerolog.New(w).With().Timestamp().Logger()
+	once.Do(func() {
+		var w io.Writer = os.Stdout
+		if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+			w = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+		}
+
+		switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
+		case "debug":
+			logLevel = zerolog.DebugLevel
+		case "info", "":
+			logLevel = zerolog.InfoLevel
+		case "warn":
+			logLevel = zerolog.WarnLevel
+		case "error":
+			logLevel = zerolog.ErrorLevel
+		default:
+			logLevel = zerolog.InfoLevel
+		}
+		l = zerolog.New(w).Level(logLevel).With().Timestamp().Logger()
+	})
+}
+
+// Level returns the configured log level.
+func Level() zerolog.Level {
+	return logLevel
 }
 
 // Info starts a new info level log event.
@@ -33,6 +59,11 @@ func Warn() *zerolog.Event {
 // Error starts a new error level log event.
 func Error() *zerolog.Event {
 	return l.Error()
+}
+
+// Debug starts a new debug level log event.
+func Debug() *zerolog.Event {
+	return l.Debug()
 }
 
 // With returns a context for adding fields to the logger.

--- a/backend/main.go
+++ b/backend/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/glebarez/sqlite"
 
+	"github.com/rs/zerolog"
 	"gorm.io/gorm"
 
 	"gen-library/backend/api"
@@ -19,6 +20,12 @@ import (
 
 func main() {
 	logger.Init()
+
+	if logger.Level() == zerolog.DebugLevel {
+		gin.SetMode(gin.DebugMode)
+	} else {
+		gin.SetMode(gin.ReleaseMode)
+	}
 
 	dbConn, err := gorm.Open(sqlite.Open("library.db"), &gorm.Config{})
 	if err != nil {


### PR DESCRIPTION
## Summary
- map `LOG_LEVEL` env variable to zerolog levels during logger initialization
- set Gin mode based on the configured logging level
- document `LOG_LEVEL` in backend configuration

## Testing
- `go test ./logger`
- `go test ./...` *(fails: hangs, dependency compile time)*

------
https://chatgpt.com/codex/tasks/task_e_68a9379b5ab88332b2253d24525206c3