### PR TITLE
Use structured gin logger with request IDs

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.10.1
 	github.com/glebarez/sqlite v1.11.0
+	github.com/google/uuid v1.6.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/rs/zerolog v1.34.0
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
@@ -33,7 +34,6 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect


### PR DESCRIPTION
## Summary
- Replace `gin.Default()` with `gin.New()` and a custom `LoggerWithFormatter`
- Add middleware to inject/propagate `X-Request-ID`
- Log method, path, status, latency and client IP via zerolog

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68a93b4bd9e08332a9c50946abea83ea