### PR TITLE
Use structured logging in scanner and watcher

### DIFF
--- a/backend/scan/scanner.go
+++ b/backend/scan/scanner.go
@@ -58,7 +58,8 @@ func ScanFolder(gdb *gorm.DB, root string) (int, error) {
 			added, err := processFile(tx, absRoot, path, ext)
 			if err != nil {
 				// Log and continue scanning
-				logger.Warn().Err(err).Msg("scan")
+				log := logger.With().Str("component", "scan").Str("path", path).Str("event", "scan").Logger()
+				log.Warn().Err(err).Msg("")
 				return nil
 			}
 			if added {
@@ -131,7 +132,8 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 	metaMap, err := extractMetadata(path, ext)
 	if err != nil {
 		// non-fatal, continue with what we have
-		logger.Warn().Str("path", path).Err(err).Msg("metadata error")
+		log := logger.With().Str("component", "scan").Str("path", path).Str("event", "metadata").Logger()
+		log.Warn().Err(err).Msg("")
 		metaMap = map[string]string{}
 	}
 
@@ -165,7 +167,8 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 				if hash != "" {
 					var existing db.Lora
 					if err := tx.Where("hash = ?", hash).First(&existing).Error; err == nil {
-						logger.Warn().Str("lora", name).Str("existing", existing.Name).Msg("hash conflict for lora; using existing")
+						log := logger.With().Str("component", "scan").Str("event", "hash_conflict").Str("lora", name).Str("existing", existing.Name).Logger()
+						log.Warn().Msg("")
 						l = existing
 					} else {
 						l = db.Lora{Name: name}
@@ -192,7 +195,8 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 			} else if *l.Hash != hash {
 				var existing db.Lora
 				if err := tx.Where("hash = ?", hash).First(&existing).Error; err == nil && existing.ID != l.ID {
-					logger.Warn().Str("lora", name).Str("existing", existing.Name).Msg("hash conflict for lora; using existing")
+					log := logger.With().Str("component", "scan").Str("event", "hash_conflict").Str("lora", name).Str("existing", existing.Name).Logger()
+					log.Warn().Msg("")
 					l = existing
 				} else if errors.Is(err, gorm.ErrRecordNotFound) {
 					l.Hash = &hash
@@ -247,7 +251,8 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 				if hash != "" {
 					var existing db.Embedding
 					if err := tx.Where("hash = ?", hash).First(&existing).Error; err == nil {
-						logger.Warn().Str("embedding", name).Str("existing", existing.Name).Msg("hash conflict for embedding; using existing")
+						log := logger.With().Str("component", "scan").Str("event", "hash_conflict").Str("embedding", name).Str("existing", existing.Name).Logger()
+						log.Warn().Msg("")
 						e = existing
 					} else {
 						e = db.Embedding{Name: name}
@@ -274,7 +279,8 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 			} else if *e.Hash != hash {
 				var existing db.Embedding
 				if err := tx.Where("hash = ?", hash).First(&existing).Error; err == nil && existing.ID != e.ID {
-					logger.Warn().Str("embedding", name).Str("existing", existing.Name).Msg("hash conflict for embedding; using existing")
+					log := logger.With().Str("component", "scan").Str("event", "hash_conflict").Str("embedding", name).Str("existing", existing.Name).Logger()
+					log.Warn().Msg("")
 					e = existing
 				} else if errors.Is(err, gorm.ErrRecordNotFound) {
 					e.Hash = &hash
@@ -328,7 +334,8 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 			} else if *model.Hash != hash {
 				var existing db.Model
 				if err := tx.Where("hash = ?", hash).First(&existing).Error; err == nil && existing.ID != model.ID {
-					logger.Warn().Str("model", name).Str("existing", existing.Name).Msg("hash conflict for model; using existing")
+					log := logger.With().Str("component", "scan").Str("event", "hash_conflict").Str("model", name).Str("existing", existing.Name).Logger()
+					log.Warn().Msg("")
 					model = &existing
 				} else if errors.Is(err, gorm.ErrRecordNotFound) {
 					model.Hash = &hash

--- a/backend/scan/watcher.go
+++ b/backend/scan/watcher.go
@@ -57,7 +57,8 @@ func IsWatcherRunning() bool {
 func runWatcher(ctx context.Context, root string, gdb *gorm.DB) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		logger.Error().Err(err).Msg("watcher")
+		log := logger.With().Str("component", "scan").Str("event", "watcher").Logger()
+		log.Error().Err(err).Msg("")
 		return
 	}
 	defer watcher.Close()
@@ -69,7 +70,8 @@ func runWatcher(ctx context.Context, root string, gdb *gorm.DB) {
 		}
 		if d.IsDir() {
 			if werr := watcher.Add(path); werr != nil {
-				logger.Warn().Str("path", path).Err(werr).Msg("watcher add")
+				log := logger.With().Str("component", "scan").Str("event", "watcher_add").Str("path", path).Logger()
+				log.Warn().Err(werr).Msg("")
 			}
 		}
 		return nil
@@ -87,7 +89,8 @@ func runWatcher(ctx context.Context, root string, gdb *gorm.DB) {
 				fi, err := os.Stat(event.Name)
 				if err == nil && fi.IsDir() {
 					if werr := watcher.Add(event.Name); werr != nil {
-						logger.Warn().Str("path", event.Name).Err(werr).Msg("watcher add")
+						log := logger.With().Str("component", "scan").Str("event", "watcher_add").Str("path", event.Name).Logger()
+						log.Warn().Err(werr).Msg("")
 					}
 					continue
 				}
@@ -97,7 +100,8 @@ func runWatcher(ctx context.Context, root string, gdb *gorm.DB) {
 					go func(p string) {
 						time.Sleep(500 * time.Millisecond)
 						if _, err := ScanFile(gdb, root, p); err != nil {
-							logger.Warn().Str("file", p).Err(err).Msg("scan file")
+							log := logger.With().Str("component", "scan").Str("event", "scan_file").Str("path", p).Logger()
+							log.Warn().Err(err).Msg("")
 						}
 					}(event.Name)
 				}
@@ -106,7 +110,8 @@ func runWatcher(ctx context.Context, root string, gdb *gorm.DB) {
 			if !ok {
 				return
 			}
-			logger.Error().Err(err).Msg("watcher error")
+			log := logger.With().Str("component", "scan").Str("event", "watcher_error").Logger()
+			log.Error().Err(err).Msg("")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- switch scan components to structured logging using logger.With
- attach component, path, and event fields instead of free-form messages

## Testing
- `go build ./scan`
- `go test ./scan -run TestParseLoraWeights -v` *(hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68a93d79a53c83329ecb83ec79a7c9e9