### PR TITLE
Fix go run for library command

### DIFF
--- a/backend/cmd/library/main.go
+++ b/backend/cmd/library/main.go
@@ -1,6 +1,3 @@
-//go:build main
-// +build main
-
 package main
 
 import (
@@ -35,6 +32,10 @@ func requestIDMiddleware() gin.HandlerFunc {
 }
 
 func main() {
+	if os.Getenv("GENLIBRARY_SKIP_SERVER") != "" {
+		return
+	}
+
 	logger.Init()
 
 	if logger.Level() == zerolog.DebugLevel {


### PR DESCRIPTION
## Summary
- remove build tag from library entrypoint so `go run ./cmd/library` works without extra tags
- allow skipping server startup when `GENLIBRARY_SKIP_SERVER` env var is set

## Testing
- `cd backend && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a94b04108c833287e0c30dda01a9a6