### PR TITLE
Configure test SQLite connections to avoid locking

### DIFF
--- a/backend/api/images_test.go
+++ b/backend/api/images_test.go
@@ -17,8 +17,10 @@ import (
 
 // setupRouter initializes an in-memory database, seeds test data and returns a gin.Engine.
 func setupRouter(t *testing.T) (*gin.Engine, bool) {
-	gdb, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	gdb, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_busy_timeout=5000"), &gorm.Config{})
 	require.NoError(t, err)
+	sqlDB, _ := gdb.DB()
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.ApplyMigrations(gdb))
 
 	// Seed tags

--- a/backend/db/migrations_test.go
+++ b/backend/db/migrations_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 func TestApplyMigrationsIsIdempotent(t *testing.T) {
-	gdb, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	gdb, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_busy_timeout=5000"), &gorm.Config{})
 	require.NoError(t, err)
+	sqlDB, _ := gdb.DB()
+	sqlDB.SetMaxOpenConns(1)
 
 	require.NoError(t, ApplyMigrations(gdb))
 	require.NoError(t, ApplyMigrations(gdb))

--- a/backend/scan/watcher_test.go
+++ b/backend/scan/watcher_test.go
@@ -17,8 +17,10 @@ import (
 
 func newTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	gdb, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	gdb, err := gorm.Open(sqlite.Open("file::memory:?cache=shared&_busy_timeout=5000"), &gorm.Config{})
 	require.NoError(t, err)
+	sqlDB, _ := gdb.DB()
+	sqlDB.SetMaxOpenConns(1)
 	require.NoError(t, db.ApplyMigrations(gdb))
 	return gdb
 }


### PR DESCRIPTION
## Summary
- add busy timeout and restrict to a single connection for test SQLite DBs
- apply the configuration to watcher, migration, and API tests

## Testing
- `go test ./backend/...` *(fails: command hung without output)*

------
https://chatgpt.com/codex/tasks/task_e_68a94a152ee483329f677f47982041c0