### PR TITLE
feat: add optional file logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The backend logger can be configured with environment variables:
 | Variable   | Description                                            |
 |------------|--------------------------------------------------------|
 | `LOG_LEVEL` | Sets the log verbosity. Accepts `debug`, `info` (default), `warn`, or `error`. |
+| `LOG_FILE`  | When set, writes logs to `logs/$(LOG_FILE)` in addition to stdout. The previous log file is rotated to `$(LOG_FILE).1`. |
+
+To enable file logging, set `LOG_FILE` to a file name. For example, `LOG_FILE=backend.log` will log to `logs/backend.log` as well as standard output.
 
 ## Todo
 

--- a/backend/cmd/library/main.go
+++ b/backend/cmd/library/main.go
@@ -36,6 +36,7 @@ func requestIDMiddleware() gin.HandlerFunc {
 
 func main() {
 	logger.Init()
+	defer logger.Close()
 
 	if logger.Level() == zerolog.DebugLevel {
 		gin.SetMode(gin.DebugMode)


### PR DESCRIPTION
## Summary
- support optional file logging via `LOG_FILE` env var
- document enabling backend file logs
- close log file on shutdown

## Testing
- `go test -tags sqlite_fts5 ./backend/...`


------
https://chatgpt.com/codex/tasks/task_e_68a94587c28c8332a34b79778cb46c26