### PR TITLE
Improve image paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ To enable file logging, set `LOG_FILE` to a file name. For example, `LOG_FILE=ba
 
 ### Gallery
 - Change NSFW button to indicator that can toggle NSFW status on the fly
-- Update pager to match Model Manager and add it to the top of the page
 
 ### Misc
 - Add icon instead of app name

--- a/frontend/src/components/Pager.vue
+++ b/frontend/src/components/Pager.vue
@@ -1,17 +1,68 @@
 <template>
-  <nav class="d-flex justify-content-between align-items-center mt-3" aria-label="pager">
-    <button class="btn btn-outline-secondary" :disabled="page <= 1" @click="$emit('change', page - 1)">Prev</button>
-    <div>
-      <span class="me-2">Page {{ page }}</span>
-      <span class="text-muted">• {{ total }} items</span>
-    </div>
-    <button class="btn btn-outline-secondary" :disabled="page >= maxPage" @click="$emit('change', page + 1)">Next</button>
+  <nav
+    v-if="totalPages > 1"
+    class="my-3"
+    aria-label="pager"
+  >
+    <ul class="pagination justify-content-center align-items-center gap-1 mb-0">
+      <li class="page-item" :class="{ disabled: page === 1 }">
+        <a class="page-link" href="#" @click.prevent="changePage(1)">First</a>
+      </li>
+      <li class="page-item" :class="{ disabled: page === 1 }">
+        <a class="page-link" href="#" @click.prevent="changePage(page - 1)">Previous</a>
+      </li>
+      <li class="d-flex align-items-center">
+        <input
+          type="number"
+          min="1"
+          :max="totalPages"
+          v-model.number="pageInput"
+          @keyup.enter="goToPage"
+          class="form-control"
+          style="width: 80px"
+        />
+        <span class="ms-1">/ {{ totalPages }}</span>
+      </li>
+      <li class="page-item" :class="{ disabled: page === totalPages }">
+        <a class="page-link" href="#" @click.prevent="changePage(page + 1)">Next</a>
+      </li>
+      <li class="page-item" :class="{ disabled: page === totalPages }">
+        <a class="page-link" href="#" @click.prevent="changePage(totalPages)">Last</a>
+      </li>
+    </ul>
   </nav>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from "vue";
 
-const props = defineProps<{ page: number; pageSize: number; total: number }>()
-const maxPage = computed(() => Math.max(1, Math.ceil(props.total / (props.pageSize || 50))))
+const props = defineProps<{ page: number; pageSize: number; total: number }>();
+const emit = defineEmits<{
+  (e: "change", page: number): void;
+}>();
+
+const totalPages = computed(() =>
+  Math.max(1, Math.ceil(props.total / (props.pageSize || 50)))
+);
+const pageInput = ref(props.page);
+
+watch(
+  () => props.page,
+  (p) => {
+    pageInput.value = p;
+  }
+);
+
+function changePage(p: number) {
+  if (p < 1 || p > totalPages.value || p === props.page) return;
+  emit("change", p);
+}
+
+function goToPage() {
+  let p = pageInput.value;
+  if (p < 1) p = 1;
+  if (p > totalPages.value) p = totalPages.value;
+  emit("change", p);
+}
 </script>
+


### PR DESCRIPTION
## Summary
- Add a first/last pager with page input and display it above and below the image grid
- Allow fullscreen viewer navigation to seamlessly cross page boundaries
- Clean up TODO about updating pager

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a956d037dc8332bed10103041dde9b