### PR TITLE
Configure SQLite busy timeout and WAL mode

### DIFF
--- a/backend/cmd/library/main.go
+++ b/backend/cmd/library/main.go
@@ -53,6 +53,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Limit to a single connection to avoid concurrent writes blocking each other
+	sqlDB, err := dbConn.DB()
+	if err != nil {
+		logger.Error().Err(err).Msg("failed to get db handle")
+		os.Exit(1)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+
 	if err := db.ApplyMigrations(dbConn); err != nil {
 		logger.Error().Err(err).Msg("migrations failed")
 		os.Exit(1)

--- a/backend/cmd/library/main.go
+++ b/backend/cmd/library/main.go
@@ -45,7 +45,9 @@ func main() {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
-	dbConn, err := gorm.Open(sqlite.Open("library.db"), &gorm.Config{})
+	// Set a busy timeout and enable WAL to reduce "database is locked" errors
+	dsn := "file:library.db?_busy_timeout=5000&_journal_mode=WAL"
+	dbConn, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to open database")
 		os.Exit(1)

--- a/backend/scan/scanner.go
+++ b/backend/scan/scanner.go
@@ -58,7 +58,7 @@ func ScanFolder(gdb *gorm.DB, root string) (int, error) {
 		if err != nil {
 			// Log and continue scanning
 			log := logger.With().Str("component", "scan").Str("path", path).Str("event", "scan").Logger()
-			log.Warn().Err(err).Msg("")
+			log.Error().Err(err).Msg("failed to add image to library")
 			return nil
 		}
 		if added {
@@ -462,6 +462,8 @@ func processFile(tx *gorm.DB, root, path, ext string) (bool, error) {
 	}
 
 	if err := tx.Create(&img).Error; err != nil {
+		log := logger.With().Str("component", "scan").Str("path", path).Str("event", "db_insert").Logger()
+		log.Error().Err(err).Msg("failed to insert image record")
 		return false, err
 	}
 	if len(loraAssocs) > 0 {


### PR DESCRIPTION
## Summary
- set a busy timeout and enable WAL mode when opening the database to reduce `database is locked` errors during large scans

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bd84826efc8332850438eebd11ad72